### PR TITLE
Secret store with UUID mapping layer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "commander": "^13.1.0"
+        "commander": "^13.1.0",
+        "uuid": "^13.0.0"
       },
       "bin": {
         "2kc": "dist/cli/index.js"
@@ -17,6 +18,7 @@
       "devDependencies": {
         "@eslint/js": "^9.20.0",
         "@types/node": "^22.13.0",
+        "@types/uuid": "^10.0.0",
         "eslint": "^9.20.0",
         "prettier": "^3.5.0",
         "tsx": "^4.19.0",
@@ -1064,6 +1066,13 @@
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.56.0",
@@ -2814,6 +2823,19 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
+      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -25,16 +25,18 @@
     "node": ">=20.0.0"
   },
   "dependencies": {
-    "commander": "^13.1.0"
+    "commander": "^13.1.0",
+    "uuid": "^13.0.0"
   },
   "devDependencies": {
-    "@types/node": "^22.13.0",
-    "eslint": "^9.20.0",
     "@eslint/js": "^9.20.0",
-    "typescript-eslint": "^8.24.0",
-    "typescript": "^5.7.0",
+    "@types/node": "^22.13.0",
+    "@types/uuid": "^10.0.0",
+    "eslint": "^9.20.0",
+    "prettier": "^3.5.0",
     "tsx": "^4.19.0",
-    "vitest": "^3.0.0",
-    "prettier": "^3.5.0"
+    "typescript": "^5.7.0",
+    "typescript-eslint": "^8.24.0",
+    "vitest": "^3.0.0"
   }
 }

--- a/src/__tests__/secret-store.test.ts
+++ b/src/__tests__/secret-store.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, statSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+import { SecretStore } from '../core/secret-store.js'
+
+const UUID_V4_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+describe('SecretStore', () => {
+  let tmpDir: string
+  let filePath: string
+  let store: SecretStore
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), '2kc-test-'))
+    filePath = join(tmpDir, 'secrets.json')
+    store = new SecretStore(filePath)
+  })
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  describe('add', () => {
+    it('should create a secret with a valid UUIDv4', () => {
+      const uuid = store.add('my-secret', 's3cret')
+      expect(uuid).toMatch(UUID_V4_REGEX)
+    })
+
+    it('should store name, value, tags, createdAt, updatedAt', () => {
+      const uuid = store.add('my-secret', 's3cret', ['api', 'prod'])
+      const metadata = store.getMetadata(uuid)
+      expect(metadata.name).toBe('my-secret')
+      expect(metadata.tags).toEqual(['api', 'prod'])
+      expect(store.getValue(uuid)).toBe('s3cret')
+    })
+
+    it('should default tags to empty array when not provided', () => {
+      const uuid = store.add('my-secret', 's3cret')
+      const metadata = store.getMetadata(uuid)
+      expect(metadata.tags).toEqual([])
+    })
+
+    it('should return the generated UUID', () => {
+      const uuid = store.add('my-secret', 's3cret')
+      expect(typeof uuid).toBe('string')
+      expect(uuid.length).toBeGreaterThan(0)
+    })
+
+    it('should throw when adding a secret with a duplicate name', () => {
+      store.add('my-secret', 'value1')
+      expect(() => store.add('my-secret', 'value2')).toThrow(
+        'A secret with the name "my-secret" already exists',
+      )
+    })
+
+    it('should allow different names', () => {
+      store.add('secret-a', 'value1')
+      const uuid = store.add('secret-b', 'value2')
+      expect(uuid).toMatch(UUID_V4_REGEX)
+    })
+  })
+
+  describe('list', () => {
+    it('should return only uuid and tags for each secret', () => {
+      store.add('secret-1', 'val1', ['tag-a'])
+      store.add('secret-2', 'val2', ['tag-b'])
+
+      const items = store.list()
+      expect(items).toHaveLength(2)
+      for (const item of items) {
+        expect(Object.keys(item).sort()).toEqual(['tags', 'uuid'])
+      }
+    })
+
+    it('should return empty array when no secrets exist', () => {
+      const items = store.list()
+      expect(items).toEqual([])
+    })
+  })
+
+  describe('remove', () => {
+    it('should remove a secret by UUID', () => {
+      const uuid = store.add('my-secret', 's3cret')
+      expect(store.list()).toHaveLength(1)
+
+      store.remove(uuid)
+      expect(store.list()).toHaveLength(0)
+    })
+
+    it('should throw for non-existent UUID', () => {
+      expect(() => store.remove('non-existent-uuid')).toThrow(
+        'Secret with UUID non-existent-uuid not found',
+      )
+    })
+  })
+
+  describe('getMetadata', () => {
+    it('should return uuid, tags, and name but NOT value', () => {
+      const uuid = store.add('my-secret', 's3cret', ['tag1'])
+      const metadata = store.getMetadata(uuid)
+
+      expect(metadata).toEqual({
+        uuid,
+        name: 'my-secret',
+        tags: ['tag1'],
+      })
+      expect(metadata).not.toHaveProperty('value')
+    })
+
+    it('should throw for non-existent UUID', () => {
+      expect(() => store.getMetadata('non-existent-uuid')).toThrow(
+        'Secret with UUID non-existent-uuid not found',
+      )
+    })
+  })
+
+  describe('getValue', () => {
+    it('should return the secret value for a valid UUID', () => {
+      const uuid = store.add('my-secret', 's3cret')
+      expect(store.getValue(uuid)).toBe('s3cret')
+    })
+
+    it('should throw for non-existent UUID', () => {
+      expect(() => store.getValue('non-existent-uuid')).toThrow(
+        'Secret with UUID non-existent-uuid not found',
+      )
+    })
+  })
+
+  describe('file handling', () => {
+    it('should create the JSON file on first write if it does not exist', () => {
+      const newPath = join(tmpDir, 'new-secrets.json')
+      const newStore = new SecretStore(newPath)
+      newStore.add('test', 'value')
+
+      const stats = statSync(newPath)
+      expect(stats.isFile()).toBe(true)
+    })
+
+    it('should create parent directories if they do not exist', () => {
+      const nestedPath = join(tmpDir, 'a', 'b', 'c', 'secrets.json')
+      const nestedStore = new SecretStore(nestedPath)
+      nestedStore.add('test', 'value')
+
+      const stats = statSync(nestedPath)
+      expect(stats.isFile()).toBe(true)
+    })
+
+    it('should set file permissions to 0600', () => {
+      store.add('test', 'value')
+
+      const stats = statSync(filePath)
+
+      const mode = stats.mode & 0o777
+      expect(mode).toBe(0o600)
+    })
+
+    it('should throw a descriptive error when the secrets file is corrupted', () => {
+      writeFileSync(filePath, 'not valid json{{{', 'utf-8')
+      expect(() => store.list()).toThrow(
+        `Failed to parse secrets file at ${filePath}. File may be corrupted.`,
+      )
+    })
+
+    it('should persist secrets across store instances (reload from file)', () => {
+      const uuid = store.add('my-secret', 's3cret', ['tag1'])
+
+      const store2 = new SecretStore(filePath)
+      const items = store2.list()
+      expect(items).toHaveLength(1)
+      expect(items[0].uuid).toBe(uuid)
+      expect(store2.getValue(uuid)).toBe('s3cret')
+    })
+  })
+})

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -4,6 +4,8 @@ import { Command } from 'commander'
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 
+import { secretsCommand } from './secrets.js'
+
 const pkg = JSON.parse(
   readFileSync(resolve(import.meta.dirname, '../../package.json'), 'utf-8'),
 ) as { version: string }
@@ -14,5 +16,7 @@ program
   .name('2kc')
   .description('A local secret broker with controlled access and approval flows')
   .version(pkg.version)
+
+program.addCommand(secretsCommand)
 
 program.parse()

--- a/src/cli/secrets.ts
+++ b/src/cli/secrets.ts
@@ -1,0 +1,82 @@
+import { Command } from 'commander'
+import { createInterface } from 'node:readline'
+
+import { SecretStore } from '../core/secret-store.js'
+
+function readStdin(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let data = ''
+    process.stdin.setEncoding('utf-8')
+    process.stdin.on('data', (chunk: string) => {
+      data += chunk
+    })
+    process.stdin.on('end', () => {
+      resolve(data.trim())
+    })
+    process.stdin.on('error', reject)
+  })
+}
+
+function promptForValue(): Promise<string> {
+  const rl = createInterface({
+    input: process.stdin,
+    output: process.stderr,
+  })
+  return new Promise((resolve) => {
+    rl.question('Enter secret value: ', (answer) => {
+      rl.close()
+      resolve(answer)
+    })
+  })
+}
+
+async function resolveValue(optValue?: string): Promise<string> {
+  if (optValue !== undefined) {
+    return optValue
+  }
+  if (!process.stdin.isTTY) {
+    return readStdin()
+  }
+  return promptForValue()
+}
+
+const secrets = new Command('secrets').description('Manage secrets in the local store')
+
+secrets
+  .command('add')
+  .description('Add a new secret')
+  .requiredOption('--name <name>', 'Human-readable name')
+  .option('--value <value>', 'Secret value (reads from stdin if omitted)')
+  .option('--tags <tags...>', 'Tags for approval config')
+  .action(async (opts: { name: string; value?: string; tags?: string[] }) => {
+    const value = await resolveValue(opts.value)
+    if (!value) {
+      console.error('Error: secret value must not be empty')
+      process.exitCode = 1
+      return
+    }
+    const store = new SecretStore()
+    const uuid = store.add(opts.name, value, opts.tags)
+    console.log(uuid)
+  })
+
+secrets
+  .command('list')
+  .description('List all secrets (UUIDs and tags only)')
+  .action(() => {
+    const store = new SecretStore()
+    const items = store.list()
+    console.log(JSON.stringify(items, null, 2))
+  })
+
+secrets
+  .command('remove')
+  .description('Remove a secret by UUID')
+  .argument('<uuid>', 'UUID of the secret to remove')
+  .action((uuid: string) => {
+    const store = new SecretStore()
+    store.remove(uuid)
+    console.log('Removed')
+  })
+
+export { secrets as secretsCommand }

--- a/src/core/secret-store.ts
+++ b/src/core/secret-store.ts
@@ -1,0 +1,90 @@
+import { v4 as uuidv4 } from 'uuid'
+import { readFileSync, writeFileSync, mkdirSync, chmodSync, existsSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { homedir } from 'node:os'
+
+import type { SecretEntry, SecretListItem, SecretMetadata, SecretsFile } from './types.js'
+
+const DEFAULT_PATH = join(homedir(), '.2kc', 'secrets.json')
+
+export class SecretStore {
+  private readonly filePath: string
+
+  constructor(filePath: string = DEFAULT_PATH) {
+    this.filePath = filePath
+  }
+
+  private load(): SecretEntry[] {
+    if (!existsSync(this.filePath)) {
+      return []
+    }
+    const data = readFileSync(this.filePath, 'utf-8')
+    try {
+      const file = JSON.parse(data) as SecretsFile
+      return file.secrets
+    } catch {
+      throw new Error(`Failed to parse secrets file at ${this.filePath}. File may be corrupted.`)
+    }
+  }
+
+  private findEntry(uuid: string): SecretEntry {
+    const secrets = this.load()
+    const entry = secrets.find((s) => s.uuid === uuid)
+    if (!entry) {
+      throw new Error(`Secret with UUID ${uuid} not found`)
+    }
+    return entry
+  }
+
+  private save(secrets: SecretEntry[]): void {
+    const dir = dirname(this.filePath)
+    mkdirSync(dir, { recursive: true })
+    const file: SecretsFile = { secrets }
+    writeFileSync(this.filePath, JSON.stringify(file, null, 2), 'utf-8')
+    chmodSync(this.filePath, 0o600)
+  }
+
+  add(name: string, value: string, tags: string[] = []): string {
+    const secrets = this.load()
+    const existing = secrets.find((s) => s.name === name)
+    if (existing) {
+      throw new Error(`A secret with the name "${name}" already exists`)
+    }
+    const uuid = uuidv4()
+    const now = new Date().toISOString()
+    const entry: SecretEntry = {
+      uuid,
+      name,
+      value,
+      tags,
+      createdAt: now,
+      updatedAt: now,
+    }
+    secrets.push(entry)
+    this.save(secrets)
+    return uuid
+  }
+
+  remove(uuid: string): boolean {
+    this.findEntry(uuid)
+    const secrets = this.load()
+    const filtered = secrets.filter((s) => s.uuid !== uuid)
+    this.save(filtered)
+    return true
+  }
+
+  list(): SecretListItem[] {
+    const secrets = this.load()
+    return secrets.map((s) => ({ uuid: s.uuid, tags: s.tags }))
+  }
+
+  getMetadata(uuid: string): SecretMetadata {
+    const entry = this.findEntry(uuid)
+    return { uuid: entry.uuid, name: entry.name, tags: entry.tags }
+  }
+
+  getValue(uuid: string): string {
+    const entry = this.findEntry(uuid)
+    return entry.value
+  }
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,0 +1,23 @@
+export interface SecretEntry {
+  uuid: string
+  name: string
+  value: string
+  tags: string[]
+  createdAt: string
+  updatedAt: string
+}
+
+export interface SecretListItem {
+  uuid: string
+  tags: string[]
+}
+
+export interface SecretMetadata {
+  uuid: string
+  name: string
+  tags: string[]
+}
+
+export interface SecretsFile {
+  secrets: SecretEntry[]
+}


### PR DESCRIPTION
Fixes #3

## Secret store with UUID mapping layer

## Summary

Implement a JSON file-backed secret store where each secret is assigned a UUID. The AI-facing interface only exposes UUIDs — never human-readable names or raw values.

## Context

The UUID mapping layer is a core security feature of v0.5. It ensures AI agents interact with opaque identifiers rather than meaningful secret names. The store is a plain JSON file (macOS Keychain integration is deferred to a later phase).

## Acceptance Criteria

- [ ] `SecretStore` class/module that reads/writes a JSON file (e.g., `~/.2kc/secrets.json`)
- [ ] Each secret entry has: `uuid`, `name` (human-readable), `value`, `tags` (array of strings for approval config), `createdAt`, `updatedAt`
- [ ] UUID generated via `uuid` package (v4) on secret creation
- [ ] Public API exposes only UUIDs and tags — never names or values directly
- [ ] Methods: `add(name, value, tags?)`, `remove(uuid)`, `list()` (returns uuid + tags only), `getMetadata(uuid)` (returns uuid + tags + name, no value), `getValue(uuid)` (internal only, used by injection)
- [ ] CLI subcommands wired up: `2kc secrets add`, `2kc secrets list`, `2kc secrets remove`
- [ ] `2kc secrets list` output shows only UUIDs and tags
- [ ] JSON file is created on first use if it doesn't exist
- [ ] File permissions set to `0600` (owner read/write only)
- [ ] Unit tests for CRUD operations and UUID generation

## Dependencies

- Issue: Project bootstrap & CLI skeleton

## Scope Boundaries

- Does NOT include approval logic (that's the workflow engine)
- Does NOT include access request handling
- Does NOT include any Discord integration
- The `getValue()` method exists but is only called by the injection system later

---
*This PR was created automatically by iloom.*