### PR TITLE
Access request model with contextual justification

### DIFF
--- a/src/__tests__/request.test.ts
+++ b/src/__tests__/request.test.ts
@@ -1,0 +1,189 @@
+/// <reference types="vitest/globals" />
+
+import { createAccessRequest, RequestLog, type AccessRequest } from '../core/request.js'
+
+describe('createAccessRequest', () => {
+  const validArgs = {
+    secretUuid: '550e8400-e29b-41d4-a716-446655440000',
+    reason: 'Need DB credentials for migration',
+    taskRef: 'JIRA-1234',
+  }
+
+  describe('happy path', () => {
+    it('creates a request with default duration', () => {
+      const req = createAccessRequest(validArgs.secretUuid, validArgs.reason, validArgs.taskRef)
+
+      expect(req.id).toBeDefined()
+      expect(req.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/)
+      expect(req.secretUuid).toBe(validArgs.secretUuid)
+      expect(req.reason).toBe(validArgs.reason)
+      expect(req.taskRef).toBe(validArgs.taskRef)
+      expect(req.durationSeconds).toBe(300)
+      expect(req.requestedAt).toBeDefined()
+      expect(new Date(req.requestedAt).toISOString()).toBe(req.requestedAt)
+      expect(req.status).toBe('pending')
+    })
+
+    it('creates a request with custom duration', () => {
+      const req = createAccessRequest(
+        validArgs.secretUuid,
+        validArgs.reason,
+        validArgs.taskRef,
+        600,
+      )
+
+      expect(req.durationSeconds).toBe(600)
+    })
+
+    it('accepts minimum duration of 30 seconds', () => {
+      const req = createAccessRequest(validArgs.secretUuid, validArgs.reason, validArgs.taskRef, 30)
+
+      expect(req.durationSeconds).toBe(30)
+    })
+
+    it('accepts maximum duration of 3600 seconds', () => {
+      const req = createAccessRequest(
+        validArgs.secretUuid,
+        validArgs.reason,
+        validArgs.taskRef,
+        3600,
+      )
+
+      expect(req.durationSeconds).toBe(3600)
+    })
+
+    it('generates unique ids for each request', () => {
+      const req1 = createAccessRequest(validArgs.secretUuid, validArgs.reason, validArgs.taskRef)
+      const req2 = createAccessRequest(validArgs.secretUuid, validArgs.reason, validArgs.taskRef)
+
+      expect(req1.id).not.toBe(req2.id)
+    })
+  })
+
+  describe('validation - secretUuid', () => {
+    it('rejects empty secretUuid', () => {
+      expect(() => createAccessRequest('', validArgs.reason, validArgs.taskRef)).toThrow(
+        'secretUuid is required and must not be empty',
+      )
+    })
+
+    it('rejects whitespace-only secretUuid', () => {
+      expect(() => createAccessRequest('   ', validArgs.reason, validArgs.taskRef)).toThrow(
+        'secretUuid is required and must not be empty',
+      )
+    })
+  })
+
+  describe('validation - reason', () => {
+    it('rejects empty reason', () => {
+      expect(() => createAccessRequest(validArgs.secretUuid, '', validArgs.taskRef)).toThrow(
+        'reason is required and must not be empty',
+      )
+    })
+
+    it('rejects whitespace-only reason', () => {
+      expect(() => createAccessRequest(validArgs.secretUuid, '   ', validArgs.taskRef)).toThrow(
+        'reason is required and must not be empty',
+      )
+    })
+  })
+
+  describe('validation - taskRef', () => {
+    it('rejects empty taskRef', () => {
+      expect(() => createAccessRequest(validArgs.secretUuid, validArgs.reason, '')).toThrow(
+        'taskRef is required and must not be empty',
+      )
+    })
+
+    it('rejects whitespace-only taskRef', () => {
+      expect(() => createAccessRequest(validArgs.secretUuid, validArgs.reason, '   ')).toThrow(
+        'taskRef is required and must not be empty',
+      )
+    })
+  })
+
+  describe('validation - durationSeconds', () => {
+    it('rejects duration below 30 seconds', () => {
+      expect(() =>
+        createAccessRequest(validArgs.secretUuid, validArgs.reason, validArgs.taskRef, 29),
+      ).toThrow('durationSeconds must be at least 30')
+    })
+
+    it('rejects duration above 3600 seconds', () => {
+      expect(() =>
+        createAccessRequest(validArgs.secretUuid, validArgs.reason, validArgs.taskRef, 3601),
+      ).toThrow('durationSeconds must be at most 3600')
+    })
+
+    it('rejects zero duration', () => {
+      expect(() =>
+        createAccessRequest(validArgs.secretUuid, validArgs.reason, validArgs.taskRef, 0),
+      ).toThrow('durationSeconds must be at least 30')
+    })
+
+    it('rejects negative duration', () => {
+      expect(() =>
+        createAccessRequest(validArgs.secretUuid, validArgs.reason, validArgs.taskRef, -1),
+      ).toThrow('durationSeconds must be at least 30')
+    })
+  })
+})
+
+describe('RequestLog', () => {
+  it('starts empty', () => {
+    const log = new RequestLog()
+
+    expect(log.size).toBe(0)
+    expect(log.getAll()).toEqual([])
+  })
+
+  it('adds and retrieves requests', () => {
+    const log = new RequestLog()
+    const req = createAccessRequest('secret-1', 'need it', 'TASK-1')
+
+    log.add(req)
+
+    expect(log.size).toBe(1)
+    expect(log.getAll()).toEqual([req])
+  })
+
+  it('retrieves requests by secretUuid', () => {
+    const log = new RequestLog()
+    const req1 = createAccessRequest('secret-1', 'reason', 'TASK-1')
+    const req2 = createAccessRequest('secret-2', 'reason', 'TASK-2')
+    const req3 = createAccessRequest('secret-1', 'another reason', 'TASK-3')
+
+    log.add(req1)
+    log.add(req2)
+    log.add(req3)
+
+    const filtered = log.getBySecretUuid('secret-1')
+    expect(filtered).toHaveLength(2)
+    expect(filtered[0]).toEqual(req1)
+    expect(filtered[1]).toEqual(req3)
+  })
+
+  it('retrieves a request by id', () => {
+    const log = new RequestLog()
+    const req = createAccessRequest('secret-1', 'reason', 'TASK-1')
+
+    log.add(req)
+
+    expect(log.getById(req.id)).toEqual(req)
+    expect(log.getById('nonexistent')).toBeUndefined()
+  })
+
+  it('returns a copy from getAll to prevent external mutation', () => {
+    const log = new RequestLog()
+    const req = createAccessRequest('secret-1', 'reason', 'TASK-1')
+    log.add(req)
+
+    const all = log.getAll()
+    expect(all).toHaveLength(1)
+
+    // Mutating the returned array should not affect the log
+    ;(all as AccessRequest[]).length = 0
+    expect(log.getAll()).toHaveLength(1)
+  })
+})
+

--- a/src/core/request.ts
+++ b/src/core/request.ts
@@ -1,0 +1,82 @@
+import { randomUUID } from 'node:crypto'
+
+export type AccessRequestStatus = 'pending' | 'approved' | 'denied' | 'expired'
+
+export interface AccessRequest {
+  id: string
+  secretUuid: string
+  reason: string
+  taskRef: string
+  durationSeconds: number
+  requestedAt: string
+  status: AccessRequestStatus
+}
+
+const MIN_DURATION_SECONDS = 30
+const MAX_DURATION_SECONDS = 3600
+const DEFAULT_DURATION_SECONDS = 300
+
+export function createAccessRequest(
+  secretUuid: string,
+  reason: string,
+  taskRef: string,
+  durationSeconds: number = DEFAULT_DURATION_SECONDS,
+): AccessRequest {
+  if (!secretUuid || secretUuid.trim().length === 0) {
+    throw new Error('secretUuid is required and must not be empty')
+  }
+
+  if (!reason || reason.trim().length === 0) {
+    throw new Error('reason is required and must not be empty')
+  }
+
+  if (!taskRef || taskRef.trim().length === 0) {
+    throw new Error('taskRef is required and must not be empty')
+  }
+
+  if (durationSeconds < MIN_DURATION_SECONDS) {
+    throw new Error(
+      `durationSeconds must be at least ${MIN_DURATION_SECONDS}, got ${durationSeconds}`,
+    )
+  }
+
+  if (durationSeconds > MAX_DURATION_SECONDS) {
+    throw new Error(
+      `durationSeconds must be at most ${MAX_DURATION_SECONDS}, got ${durationSeconds}`,
+    )
+  }
+
+  return {
+    id: randomUUID(),
+    secretUuid,
+    reason,
+    taskRef,
+    durationSeconds,
+    requestedAt: new Date().toISOString(),
+    status: 'pending',
+  }
+}
+
+export class RequestLog {
+  private requests: AccessRequest[] = []
+
+  add(request: AccessRequest): void {
+    this.requests.push(request)
+  }
+
+  getAll(): ReadonlyArray<AccessRequest> {
+    return [...this.requests]
+  }
+
+  getBySecretUuid(secretUuid: string): ReadonlyArray<AccessRequest> {
+    return this.requests.filter((r) => r.secretUuid === secretUuid)
+  }
+
+  getById(id: string): AccessRequest | undefined {
+    return this.requests.find((r) => r.id === id)
+  }
+
+  get size(): number {
+    return this.requests.length
+  }
+}


### PR DESCRIPTION
Fixes #5

## Access request model with contextual justification

## Summary

Define the data model for secret access requests, including mandatory contextual justification fields, and implement validation logic.

## Context

Per the ROADMAP, every access request must include a reason, task reference, and requested duration. This prevents casual or unexplained secret access and creates an audit trail.

## Acceptance Criteria

- [ ] `AccessRequest` type/interface in `src/core/request.ts` with fields:
  - `id`: string (UUID, auto-generated)
  - `secretUuid`: string (the secret being requested)
  - `reason`: string (why access is needed — required, non-empty)
  - `taskRef`: string (ticket/job/commit reference — required, non-empty)
  - `durationSeconds`: number (requested access window, default: 300 = 5 minutes)
  - `requestedAt`: ISO timestamp
  - `status`: `'pending' | 'approved' | 'denied' | 'expired'`
- [ ] `createAccessRequest(secretUuid, reason, taskRef, durationSeconds?)` factory function with validation
- [ ] Validation: rejects empty reason, empty taskRef, duration < 30s or > 3600s (1 hour max)
- [ ] `RequestLog` — in-memory list of recent requests for audit purposes
- [ ] Unit tests for validation (happy path + rejection cases)

## Dependencies

- Issue: Project bootstrap & CLI skeleton

## Scope Boundaries

- Does NOT include approval logic (that's the workflow engine)
- Does NOT include Discord integration
- Does NOT include time-bound access grant management
- This is the data model and validation only

---
*This PR was created automatically by iloom.*