### PR TITLE
Time-bound access grants & expiration enforcement

### DIFF
--- a/src/__tests__/grant.test.ts
+++ b/src/__tests__/grant.test.ts
@@ -1,0 +1,320 @@
+/// <reference types="vitest/globals" />
+
+import { GrantManager } from '../core/grant.js'
+import { createAccessRequest } from '../core/request.js'
+
+function makeApprovedRequest(durationSeconds = 300) {
+  const request = createAccessRequest(
+    '550e8400-e29b-41d4-a716-446655440000',
+    'Need DB credentials for migration',
+    'JIRA-1234',
+    durationSeconds,
+  )
+  request.status = 'approved'
+  return request
+}
+
+function makePendingRequest(durationSeconds = 300) {
+  return createAccessRequest(
+    '550e8400-e29b-41d4-a716-446655440000',
+    'Need DB credentials for migration',
+    'JIRA-1234',
+    durationSeconds,
+  )
+}
+
+describe('GrantManager', () => {
+  describe('createGrant', () => {
+    it('creates a grant with a UUID id', () => {
+      const manager = new GrantManager()
+      const request = makeApprovedRequest()
+      const grant = manager.createGrant(request)
+
+      expect(grant.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/)
+    })
+
+    it('sets requestId to request.id', () => {
+      const manager = new GrantManager()
+      const request = makeApprovedRequest()
+      const grant = manager.createGrant(request)
+
+      expect(grant.requestId).toBe(request.id)
+    })
+
+    it('sets secretUuid from request.secretUuid', () => {
+      const manager = new GrantManager()
+      const request = makeApprovedRequest()
+      const grant = manager.createGrant(request)
+
+      expect(grant.secretUuid).toBe(request.secretUuid)
+    })
+
+    it('sets used to false and revokedAt to null', () => {
+      const manager = new GrantManager()
+      const request = makeApprovedRequest()
+      const grant = manager.createGrant(request)
+
+      expect(grant.used).toBe(false)
+      expect(grant.revokedAt).toBeNull()
+    })
+
+    it('throws if request is not approved', () => {
+      const manager = new GrantManager()
+      const request = makePendingRequest()
+
+      expect(() => manager.createGrant(request)).toThrow(
+        'Cannot create grant for request with status: pending',
+      )
+    })
+
+    describe('with fake timers', () => {
+      beforeEach(() => {
+        vi.useFakeTimers()
+        vi.setSystemTime(new Date('2026-01-15T10:00:00.000Z'))
+      })
+
+      afterEach(() => {
+        vi.useRealTimers()
+      })
+
+      it('sets grantedAt to current ISO timestamp', () => {
+        const manager = new GrantManager()
+        const request = makeApprovedRequest()
+        const grant = manager.createGrant(request)
+
+        expect(grant.grantedAt).toBe('2026-01-15T10:00:00.000Z')
+      })
+
+      it('sets expiresAt to grantedAt + durationSeconds', () => {
+        const manager = new GrantManager()
+        const request = makeApprovedRequest(300)
+        const grant = manager.createGrant(request)
+
+        expect(grant.expiresAt).toBe('2026-01-15T10:05:00.000Z')
+      })
+    })
+  })
+
+  describe('validateGrant', () => {
+    it('returns true for valid, unexpired, unused, unrevoked grant', () => {
+      const manager = new GrantManager()
+      const request = makeApprovedRequest()
+      const grant = manager.createGrant(request)
+
+      expect(manager.validateGrant(grant.id)).toBe(true)
+    })
+
+    it('returns false for non-existent grantId', () => {
+      const manager = new GrantManager()
+
+      expect(manager.validateGrant('nonexistent')).toBe(false)
+    })
+
+    it('returns false for used grant', () => {
+      const manager = new GrantManager()
+      const request = makeApprovedRequest()
+      const grant = manager.createGrant(request)
+
+      manager.markUsed(grant.id)
+
+      expect(manager.validateGrant(grant.id)).toBe(false)
+    })
+
+    it('returns false for revoked grant', () => {
+      const manager = new GrantManager()
+      const request = makeApprovedRequest()
+      const grant = manager.createGrant(request)
+
+      manager.revokeGrant(grant.id)
+
+      expect(manager.validateGrant(grant.id)).toBe(false)
+    })
+
+    describe('with fake timers', () => {
+      beforeEach(() => {
+        vi.useFakeTimers()
+        vi.setSystemTime(new Date('2026-01-15T10:00:00.000Z'))
+      })
+
+      afterEach(() => {
+        vi.useRealTimers()
+      })
+
+      it('returns false for expired grant', () => {
+        const manager = new GrantManager()
+        const request = makeApprovedRequest(300)
+        const grant = manager.createGrant(request)
+
+        // Advance past expiry
+        vi.setSystemTime(new Date('2026-01-15T10:05:00.001Z'))
+
+        expect(manager.validateGrant(grant.id)).toBe(false)
+      })
+    })
+  })
+
+  describe('markUsed', () => {
+    it('marks grant as used', () => {
+      const manager = new GrantManager()
+      const request = makeApprovedRequest()
+      const grant = manager.createGrant(request)
+
+      manager.markUsed(grant.id)
+
+      const updated = manager.getGrant(grant.id)
+      expect(updated?.used).toBe(true)
+    })
+
+    it('throws for non-existent grantId', () => {
+      const manager = new GrantManager()
+
+      expect(() => manager.markUsed('nonexistent')).toThrow('Grant not found: nonexistent')
+    })
+
+    it('throws if grant already used', () => {
+      const manager = new GrantManager()
+      const request = makeApprovedRequest()
+      const grant = manager.createGrant(request)
+
+      manager.markUsed(grant.id)
+
+      expect(() => manager.markUsed(grant.id)).toThrow(`Grant is not valid: ${grant.id}`)
+    })
+
+    it('throws if grant revoked', () => {
+      const manager = new GrantManager()
+      const request = makeApprovedRequest()
+      const grant = manager.createGrant(request)
+
+      manager.revokeGrant(grant.id)
+
+      expect(() => manager.markUsed(grant.id)).toThrow(`Grant is not valid: ${grant.id}`)
+    })
+
+    describe('with fake timers', () => {
+      beforeEach(() => {
+        vi.useFakeTimers()
+        vi.setSystemTime(new Date('2026-01-15T10:00:00.000Z'))
+      })
+
+      afterEach(() => {
+        vi.useRealTimers()
+      })
+
+      it('throws if grant expired', () => {
+        const manager = new GrantManager()
+        const request = makeApprovedRequest(300)
+        const grant = manager.createGrant(request)
+
+        vi.setSystemTime(new Date('2026-01-15T10:05:00.001Z'))
+
+        expect(() => manager.markUsed(grant.id)).toThrow(`Grant is not valid: ${grant.id}`)
+      })
+    })
+  })
+
+  describe('revokeGrant', () => {
+    it('throws for non-existent grantId', () => {
+      const manager = new GrantManager()
+
+      expect(() => manager.revokeGrant('nonexistent')).toThrow('Grant not found: nonexistent')
+    })
+
+    it('throws if grant already revoked', () => {
+      const manager = new GrantManager()
+      const request = makeApprovedRequest()
+      const grant = manager.createGrant(request)
+
+      manager.revokeGrant(grant.id)
+
+      expect(() => manager.revokeGrant(grant.id)).toThrow(`Grant already revoked: ${grant.id}`)
+    })
+
+    describe('with fake timers', () => {
+      beforeEach(() => {
+        vi.useFakeTimers()
+        vi.setSystemTime(new Date('2026-01-15T10:00:00.000Z'))
+      })
+
+      afterEach(() => {
+        vi.useRealTimers()
+      })
+
+      it('sets revokedAt timestamp', () => {
+        const manager = new GrantManager()
+        const request = makeApprovedRequest()
+        const grant = manager.createGrant(request)
+
+        vi.setSystemTime(new Date('2026-01-15T10:01:00.000Z'))
+        manager.revokeGrant(grant.id)
+
+        const updated = manager.getGrant(grant.id)
+        expect(updated?.revokedAt).toBe('2026-01-15T10:01:00.000Z')
+      })
+    })
+  })
+
+  describe('cleanup', () => {
+    it('works on empty store', () => {
+      const manager = new GrantManager()
+
+      expect(() => manager.cleanup()).not.toThrow()
+    })
+
+    describe('with fake timers', () => {
+      beforeEach(() => {
+        vi.useFakeTimers()
+        vi.setSystemTime(new Date('2026-01-15T10:00:00.000Z'))
+      })
+
+      afterEach(() => {
+        vi.useRealTimers()
+      })
+
+      it('removes expired grants from memory', () => {
+        const manager = new GrantManager()
+        const request = makeApprovedRequest(300)
+        const grant = manager.createGrant(request)
+
+        vi.setSystemTime(new Date('2026-01-15T10:05:00.001Z'))
+        manager.cleanup()
+
+        expect(manager.getGrant(grant.id)).toBeUndefined()
+      })
+
+      it('keeps unexpired grants', () => {
+        const manager = new GrantManager()
+        const request = makeApprovedRequest(300)
+        const grant = manager.createGrant(request)
+
+        vi.setSystemTime(new Date('2026-01-15T10:04:00.000Z'))
+        manager.cleanup()
+
+        expect(manager.getGrant(grant.id)).toBeDefined()
+      })
+    })
+  })
+
+  describe('getGrant', () => {
+    it('returns a copy of the grant', () => {
+      const manager = new GrantManager()
+      const request = makeApprovedRequest()
+      const grant = manager.createGrant(request)
+
+      const retrieved = manager.getGrant(grant.id)
+      expect(retrieved).toEqual(grant)
+
+      // Mutating returned copy should not affect stored grant
+      if (retrieved) {
+        retrieved.used = true
+      }
+      expect(manager.getGrant(grant.id)?.used).toBe(false)
+    })
+
+    it('returns undefined for non-existent grantId', () => {
+      const manager = new GrantManager()
+
+      expect(manager.getGrant('nonexistent')).toBeUndefined()
+    })
+  })
+})

--- a/src/core/grant.ts
+++ b/src/core/grant.ts
@@ -1,0 +1,81 @@
+import { randomUUID } from 'node:crypto'
+import type { AccessRequest } from './request.js'
+
+export interface AccessGrant {
+  id: string
+  requestId: string
+  secretUuid: string
+  grantedAt: string
+  expiresAt: string
+  used: boolean
+  revokedAt: string | null
+}
+
+export class GrantManager {
+  private grants: Map<string, AccessGrant> = new Map()
+
+  createGrant(request: AccessRequest): AccessGrant {
+    if (request.status !== 'approved') {
+      throw new Error(`Cannot create grant for request with status: ${request.status}`)
+    }
+    const now = Date.now()
+    const grant: AccessGrant = {
+      id: randomUUID(),
+      requestId: request.id,
+      secretUuid: request.secretUuid,
+      grantedAt: new Date(now).toISOString(),
+      expiresAt: new Date(now + request.durationSeconds * 1000).toISOString(),
+      used: false,
+      revokedAt: null,
+    }
+    this.grants.set(grant.id, grant)
+    return grant
+  }
+
+  validateGrant(grantId: string): boolean {
+    const grant = this.grants.get(grantId)
+    if (!grant) return false
+    if (Date.now() > new Date(grant.expiresAt).getTime()) return false
+    if (grant.used) return false
+    if (grant.revokedAt !== null) return false
+    return true
+  }
+
+  markUsed(grantId: string): void {
+    const grant = this.grants.get(grantId)
+    if (!grant) {
+      throw new Error(`Grant not found: ${grantId}`)
+    }
+    if (!this.validateGrant(grantId)) {
+      throw new Error(`Grant is not valid: ${grantId}`)
+    }
+    grant.used = true
+  }
+
+  revokeGrant(grantId: string): void {
+    const grant = this.grants.get(grantId)
+    if (!grant) {
+      throw new Error(`Grant not found: ${grantId}`)
+    }
+    if (grant.revokedAt !== null) {
+      throw new Error(`Grant already revoked: ${grantId}`)
+    }
+    grant.revokedAt = new Date().toISOString()
+  }
+
+  cleanup(): void {
+    const now = Date.now()
+    // Deleting from a Map during for..of iteration is safe per the ES spec.
+    for (const [id, grant] of this.grants) {
+      if (now > new Date(grant.expiresAt).getTime()) {
+        this.grants.delete(id)
+      }
+    }
+  }
+
+  getGrant(grantId: string): AccessGrant | undefined {
+    const grant = this.grants.get(grantId)
+    if (!grant) return undefined
+    return { ...grant }
+  }
+}


### PR DESCRIPTION
Fixes #7

## Time-bound access grants & expiration enforcement

## Summary

Implement time-limited access grants that are created upon approval and automatically expire. Any attempt to use an expired grant is denied.

## Context

Per the ROADMAP, access is granted for a short window (default 5 minutes) with auto-expiration and no persistent caching. This ensures secrets are only available for the duration needed.

## Acceptance Criteria

- [ ] `AccessGrant` type in `src/core/grant.ts` with fields:
  - `id`: string (UUID)
  - `requestId`: string (link back to the access request)
  - `secretUuid`: string
  - `grantedAt`: ISO timestamp
  - `expiresAt`: ISO timestamp
  - `used`: boolean
  - `revokedAt`: ISO timestamp | null
- [ ] `GrantManager` class that:
  - `createGrant(request: AccessRequest): AccessGrant` — creates a time-bound grant
  - `validateGrant(grantId: string): boolean` — checks if grant exists, is not expired, not used, not revoked
  - `markUsed(grantId: string): void` — marks grant as consumed (single-use)
  - `revokeGrant(grantId: string): void` — manual revocation
  - `cleanup(): void` — purges expired grants from memory
- [ ] Grants are stored **in-memory only** (not persisted to disk — stateless design)
- [ ] Expiration check: `Date.now() > expiresAt` → denied
- [ ] Single-use enforcement: a grant can only be used once for injection
- [ ] Unit tests:
  - Grant created with correct TTL
  - Valid grant passes validation
  - Expired grant rejected
  - Used grant rejected
  - Revoked grant rejected

## Dependencies

- Issue: Approval workflow engine with tag-based config (#6)

## Scope Boundaries

- Does NOT include the injection mechanism (that's the next issue)
- Does NOT include persistent grant storage (grants are ephemeral by design)
- Does NOT include rate limiting (post-MVP)

---
*This PR was created automatically by iloom.*