### PR TITLE
End-to-end CLI integration & audit logging

### DIFF
--- a/src/__tests__/config-command.test.ts
+++ b/src/__tests__/config-command.test.ts
@@ -1,0 +1,227 @@
+/// <reference types="vitest/globals" />
+
+vi.mock('node:fs', () => ({
+  readFileSync: vi.fn(),
+  writeFileSync: vi.fn(),
+  mkdirSync: vi.fn(),
+  chmodSync: vi.fn(),
+}))
+
+vi.mock('node:os', () => ({
+  homedir: vi.fn(() => '/tmp/test-home'),
+}))
+
+import { readFileSync, writeFileSync, mkdirSync, chmodSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { saveConfig, CONFIG_PATH, type AppConfig } from '../core/config.js'
+
+const mockReadFileSync = vi.mocked(readFileSync)
+const mockWriteFileSync = vi.mocked(writeFileSync)
+const mockMkdirSync = vi.mocked(mkdirSync)
+const mockChmodSync = vi.mocked(chmodSync)
+
+function createValidConfig(overrides?: Partial<AppConfig>): AppConfig {
+  return {
+    discord: {
+      webhookUrl: 'https://discord.com/api/webhooks/123/abc',
+      botToken: 'bot-token-1234567890',
+      channelId: '999888777',
+    },
+    requireApproval: {},
+    defaultRequireApproval: false,
+    approvalTimeoutMs: 300_000,
+    ...overrides,
+  }
+}
+
+describe('saveConfig', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('creates ~/.2kc directory if missing', () => {
+    const config = createValidConfig()
+    saveConfig(config)
+
+    expect(mockMkdirSync).toHaveBeenCalledWith(join('/tmp/test-home', '.2kc'), { recursive: true })
+  })
+
+  it('writes valid JSON with correct structure', () => {
+    const config = createValidConfig()
+    saveConfig(config)
+
+    expect(mockWriteFileSync).toHaveBeenCalledWith(
+      CONFIG_PATH,
+      JSON.stringify(config, null, 2),
+      'utf-8',
+    )
+  })
+
+  it('sets file permissions to 0o600', () => {
+    const config = createValidConfig()
+    saveConfig(config)
+
+    expect(mockChmodSync).toHaveBeenCalledWith(CONFIG_PATH, 0o600)
+  })
+})
+
+describe('config init action', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('accepts all values via flags (non-interactive)', async () => {
+    const { configCommand } = await import('../cli/config.js')
+
+    await configCommand.parseAsync(
+      [
+        'init',
+        '--webhook-url',
+        'https://discord.com/api/webhooks/999/xyz',
+        '--bot-token',
+        'my-bot-token',
+        '--channel-id',
+        '112233',
+      ],
+      { from: 'user' },
+    )
+
+    expect(mockWriteFileSync).toHaveBeenCalledOnce()
+    const writtenJson = mockWriteFileSync.mock.calls[0][1] as string
+    const writtenConfig = JSON.parse(writtenJson) as AppConfig
+    expect(writtenConfig.discord.webhookUrl).toBe('https://discord.com/api/webhooks/999/xyz')
+    expect(writtenConfig.discord.botToken).toBe('my-bot-token')
+    expect(writtenConfig.discord.channelId).toBe('112233')
+  })
+
+  it('uses defaults for approvalTimeoutMs and defaultRequireApproval when not provided', async () => {
+    const { configCommand } = await import('../cli/config.js')
+
+    await configCommand.parseAsync(
+      [
+        'init',
+        '--webhook-url',
+        'https://discord.com/api/webhooks/999/xyz',
+        '--bot-token',
+        'my-bot-token',
+        '--channel-id',
+        '112233',
+      ],
+      { from: 'user' },
+    )
+
+    const writtenJson = mockWriteFileSync.mock.calls[0][1] as string
+    const writtenConfig = JSON.parse(writtenJson) as AppConfig
+    expect(writtenConfig.defaultRequireApproval).toBe(false)
+    expect(writtenConfig.approvalTimeoutMs).toBe(300_000)
+  })
+
+  it('calls saveConfig with correct AppConfig shape', async () => {
+    const { configCommand } = await import('../cli/config.js')
+
+    await configCommand.parseAsync(
+      [
+        'init',
+        '--webhook-url',
+        'https://discord.com/api/webhooks/999/xyz',
+        '--bot-token',
+        'my-bot-token',
+        '--channel-id',
+        '112233',
+        '--approval-timeout',
+        '60000',
+      ],
+      { from: 'user' },
+    )
+
+    const writtenJson = mockWriteFileSync.mock.calls[0][1] as string
+    const writtenConfig = JSON.parse(writtenJson) as AppConfig
+    expect(writtenConfig).toEqual({
+      discord: {
+        webhookUrl: 'https://discord.com/api/webhooks/999/xyz',
+        botToken: 'my-bot-token',
+        channelId: '112233',
+      },
+      requireApproval: {},
+      defaultRequireApproval: false,
+      approvalTimeoutMs: 60_000,
+    })
+  })
+})
+
+describe('config show action', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('loads and displays config', async () => {
+    const config = createValidConfig()
+    mockReadFileSync.mockReturnValue(JSON.stringify(config))
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    const { configCommand } = await import('../cli/config.js')
+    await configCommand.parseAsync(['show'], { from: 'user' })
+
+    expect(logSpy).toHaveBeenCalledOnce()
+    const output = JSON.parse(logSpy.mock.calls[0][0] as string) as Record<string, unknown>
+    expect(output).toHaveProperty('discord')
+  })
+
+  it('redacts botToken (shows first 4 chars + "...")', async () => {
+    const config = createValidConfig({
+      discord: {
+        webhookUrl: 'https://discord.com/api/webhooks/123/abcdefghij',
+        botToken: 'bot-token-1234567890',
+        channelId: '999888777',
+      },
+    })
+    mockReadFileSync.mockReturnValue(JSON.stringify(config))
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    const { configCommand } = await import('../cli/config.js')
+    await configCommand.parseAsync(['show'], { from: 'user' })
+
+    const output = JSON.parse(logSpy.mock.calls[0][0] as string) as {
+      discord: { botToken: string }
+    }
+    expect(output.discord.botToken).toBe('bot-...')
+  })
+
+  it('redacts webhookUrl (shows first 20 chars + "...")', async () => {
+    const config = createValidConfig({
+      discord: {
+        webhookUrl: 'https://discord.com/api/webhooks/123/abcdefghij',
+        botToken: 'bot-token-1234567890',
+        channelId: '999888777',
+      },
+    })
+    mockReadFileSync.mockReturnValue(JSON.stringify(config))
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    const { configCommand } = await import('../cli/config.js')
+    await configCommand.parseAsync(['show'], { from: 'user' })
+
+    const output = JSON.parse(logSpy.mock.calls[0][0] as string) as {
+      discord: { webhookUrl: string }
+    }
+    expect(output.discord.webhookUrl).toBe('https://discord.com/...')
+  })
+
+  it('errors with actionable message when config file missing', async () => {
+    const err = new Error('ENOENT') as NodeJS.ErrnoException
+    err.code = 'ENOENT'
+    mockReadFileSync.mockImplementation(() => {
+      throw err
+    })
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const { configCommand } = await import('../cli/config.js')
+    const savedExitCode = process.exitCode
+    await configCommand.parseAsync(['show'], { from: 'user' })
+
+    expect(errorSpy).toHaveBeenCalledWith('No config found. Run: 2kc config init')
+    expect(process.exitCode).toBe(1)
+    process.exitCode = savedExitCode
+  })
+})

--- a/src/__tests__/request-command.test.ts
+++ b/src/__tests__/request-command.test.ts
@@ -1,0 +1,291 @@
+/// <reference types="vitest/globals" />
+
+import type { AppConfig } from '../core/config.js'
+import type { AccessRequest } from '../core/request.js'
+import type { AccessGrant } from '../core/grant.js'
+import type { ProcessResult } from '../core/types.js'
+
+const mockLoadConfig = vi.fn<() => AppConfig>()
+const mockSendNotification = vi.fn<(message: string) => Promise<void>>()
+const mockSendApprovalRequest = vi.fn<() => Promise<string>>()
+const mockWaitForResponse = vi.fn<() => Promise<'approved' | 'denied' | 'timeout'>>()
+const mockProcessRequest = vi.fn<() => Promise<'approved' | 'denied' | 'timeout'>>()
+const mockCreateGrant = vi.fn<(req: AccessRequest) => AccessGrant>()
+const mockValidateGrant = vi.fn<() => boolean>()
+const mockGetGrant = vi.fn()
+const mockMarkUsed = vi.fn()
+const mockInject = vi.fn<() => Promise<ProcessResult>>()
+const mockCreateAccessRequest = vi.fn(
+  (secretUuid: string, reason: string, taskRef: string, durationSeconds: number) => ({
+    id: 'test-request-id',
+    secretUuid,
+    reason,
+    taskRef,
+    durationSeconds,
+    requestedAt: '2026-01-01T00:00:00.000Z',
+    status: 'pending' as const,
+  }),
+)
+
+vi.mock('../core/config.js', () => ({
+  loadConfig: (...args: unknown[]) => mockLoadConfig(...(args as [])),
+}))
+
+vi.mock('../core/secret-store.js', () => ({
+  SecretStore: vi.fn(),
+}))
+
+vi.mock('../channels/discord.js', () => ({
+  DiscordChannel: vi.fn().mockImplementation(() => ({
+    sendApprovalRequest: mockSendApprovalRequest,
+    waitForResponse: mockWaitForResponse,
+    sendNotification: (...args: unknown[]) => mockSendNotification(...(args as [string])),
+  })),
+}))
+
+vi.mock('../core/workflow.js', () => ({
+  WorkflowEngine: vi.fn().mockImplementation(() => ({
+    processRequest: (...args: unknown[]) => mockProcessRequest(...(args as [])),
+  })),
+}))
+
+vi.mock('../core/grant.js', () => ({
+  GrantManager: vi.fn().mockImplementation(() => ({
+    createGrant: (...args: unknown[]) => mockCreateGrant(...(args as [AccessRequest])),
+    validateGrant: (...args: unknown[]) => mockValidateGrant(...(args as [])),
+    getGrant: (...args: unknown[]) => mockGetGrant(...(args as [])),
+    markUsed: (...args: unknown[]) => mockMarkUsed(...(args as [])),
+  })),
+}))
+
+vi.mock('../core/injector.js', () => ({
+  SecretInjector: vi.fn().mockImplementation(() => ({
+    inject: (...args: unknown[]) => mockInject(...(args as [])),
+  })),
+}))
+
+vi.mock('../core/request.js', () => ({
+  createAccessRequest: (...args: unknown[]) =>
+    mockCreateAccessRequest(...(args as [string, string, string, number])),
+}))
+
+function createTestConfig(): AppConfig {
+  return {
+    discord: {
+      webhookUrl: 'https://discord.com/api/webhooks/123/abc',
+      botToken: 'bot-token-123',
+      channelId: '999888777',
+    },
+    requireApproval: {},
+    defaultRequireApproval: false,
+    approvalTimeoutMs: 300_000,
+  }
+}
+
+function createTestGrant(overrides?: Partial<AccessGrant>): AccessGrant {
+  return {
+    id: 'test-grant-id',
+    requestId: 'test-request-id',
+    secretUuid: 'test-secret-uuid',
+    grantedAt: '2026-01-01T00:00:00.000Z',
+    expiresAt: '2026-01-01T00:05:00.000Z',
+    used: false,
+    revokedAt: null,
+    ...overrides,
+  }
+}
+
+const baseArgs = [
+  'test-secret-uuid',
+  '--reason',
+  'need for deploy',
+  '--task',
+  'TICKET-123',
+  '--env',
+  'MY_SECRET',
+  '--cmd',
+  'echo hello',
+]
+
+async function runRequest(args: string[] = baseArgs): Promise<void> {
+  const { requestCommand } = await import('../cli/request.js')
+  await requestCommand.parseAsync(args, { from: 'user' })
+}
+
+describe('request command orchestration', () => {
+  let savedExitCode: number | undefined
+
+  beforeEach(() => {
+    savedExitCode = process.exitCode
+    process.exitCode = undefined
+
+    mockLoadConfig.mockReturnValue(createTestConfig())
+    mockProcessRequest.mockResolvedValue('approved')
+    mockCreateGrant.mockReturnValue(createTestGrant())
+    mockInject.mockResolvedValue({ exitCode: 0, stdout: 'output', stderr: '' })
+    mockSendNotification.mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    process.exitCode = savedExitCode
+    vi.clearAllMocks()
+  })
+
+  it('happy path: approved request -> grant -> inject -> returns child exit code', async () => {
+    const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+    await runRequest()
+
+    expect(mockLoadConfig).toHaveBeenCalled()
+    expect(mockProcessRequest).toHaveBeenCalled()
+    expect(mockCreateGrant).toHaveBeenCalled()
+    expect(mockInject).toHaveBeenCalledWith('test-grant-id', 'MY_SECRET', [
+      'sh',
+      '-c',
+      'echo hello',
+    ])
+    expect(stdoutSpy).toHaveBeenCalledWith('output')
+    expect(process.exitCode).toBe(0)
+    stdoutSpy.mockRestore()
+  })
+
+  it('sends 4 audit log notifications in correct order', async () => {
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+    await runRequest()
+
+    expect(mockSendNotification).toHaveBeenCalledTimes(4)
+    const calls = mockSendNotification.mock.calls.map((c) => c[0] as string)
+    expect(calls[0]).toContain('Request created')
+    expect(calls[1]).toContain('Approval approved')
+    expect(calls[2]).toContain('Secret injected')
+    expect(calls[3]).toContain('Grant used')
+  })
+
+  it('audit log messages include request ID and timestamp', async () => {
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+    await runRequest()
+
+    const calls = mockSendNotification.mock.calls.map((c) => c[0] as string)
+    for (const msg of calls) {
+      expect(msg).toContain('[test-request-id]')
+      // ISO timestamp pattern: YYYY-MM-DDTHH:mm:ss
+      expect(msg).toMatch(/\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/)
+    }
+  })
+
+  it('audit log for injection does NOT include secret value', async () => {
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+    await runRequest()
+
+    const injectionMsg = mockSendNotification.mock.calls[2][0] as string
+    expect(injectionMsg).toContain('Secret injected')
+    expect(injectionMsg).toContain('env=MY_SECRET')
+    expect(injectionMsg).toContain('command=')
+    // Should not contain any secret value -- only metadata
+    expect(injectionMsg).not.toContain('bot-token')
+  })
+
+  it('denied request: logs denial, exits with code 1, does NOT create grant', async () => {
+    mockProcessRequest.mockResolvedValue('denied')
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    await runRequest()
+
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('denied'))
+    expect(process.exitCode).toBe(1)
+    expect(mockCreateGrant).not.toHaveBeenCalled()
+    errorSpy.mockRestore()
+  })
+
+  it('timeout request: logs timeout, exits with code 1', async () => {
+    mockProcessRequest.mockResolvedValue('timeout')
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    await runRequest()
+
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('timeout'))
+    expect(process.exitCode).toBe(1)
+    expect(mockCreateGrant).not.toHaveBeenCalled()
+    errorSpy.mockRestore()
+  })
+
+  it('config file missing: prints actionable error pointing to "2kc config init"', async () => {
+    const configError = new Error('Config file not found: /path/to/config.json')
+    mockLoadConfig.mockImplementation(() => {
+      throw configError
+    })
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    await runRequest()
+
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('config init'))
+    expect(process.exitCode).toBe(1)
+    errorSpy.mockRestore()
+  })
+
+  it('audit log failure (sendNotification throws): prints warning to stderr, continues main flow', async () => {
+    mockSendNotification.mockRejectedValue(new Error('Discord down'))
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+    await runRequest()
+
+    // Should still complete the flow successfully
+    expect(mockInject).toHaveBeenCalled()
+    expect(stdoutSpy).toHaveBeenCalledWith('output')
+    expect(process.exitCode).toBe(0)
+
+    // Should have printed warnings for each failed audit
+    const errorCalls = errorSpy.mock.calls.map((c) => c[0] as string)
+    const auditWarnings = errorCalls.filter((msg) => msg.includes('[audit] Warning'))
+    expect(auditWarnings.length).toBeGreaterThan(0)
+    stdoutSpy.mockRestore()
+    errorSpy.mockRestore()
+  })
+
+  it('child process failure: still logs grant-used audit event', async () => {
+    mockInject.mockResolvedValue({ exitCode: 1, stdout: '', stderr: 'error output' })
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+    await runRequest()
+
+    // All 4 audit logs should still be sent
+    expect(mockSendNotification).toHaveBeenCalledTimes(4)
+    const lastAuditMsg = mockSendNotification.mock.calls[3][0] as string
+    expect(lastAuditMsg).toContain('Grant used')
+
+    expect(stderrSpy).toHaveBeenCalledWith('error output')
+    expect(process.exitCode).toBe(1)
+    stderrSpy.mockRestore()
+  })
+
+  it('--duration flag is passed through to createAccessRequest', async () => {
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+    await runRequest([
+      'test-secret-uuid',
+      '--reason',
+      'need for deploy',
+      '--task',
+      'TICKET-123',
+      '--env',
+      'MY_SECRET',
+      '--cmd',
+      'echo hello',
+      '--duration',
+      '600',
+    ])
+
+    expect(mockCreateAccessRequest).toHaveBeenCalledWith(
+      'test-secret-uuid',
+      'need for deploy',
+      'TICKET-123',
+      600,
+    )
+  })
+
+  it('--duration defaults to 300 when not provided', async () => {
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+    await runRequest()
+
+    expect(mockCreateAccessRequest).toHaveBeenCalledWith(
+      'test-secret-uuid',
+      'need for deploy',
+      'TICKET-123',
+      300,
+    )
+  })
+})

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -1,0 +1,112 @@
+import { Command } from 'commander'
+import { createInterface } from 'node:readline'
+
+import { loadConfig, saveConfig, CONFIG_PATH, type AppConfig } from '../core/config.js'
+
+function promptForInput(question: string): Promise<string> {
+  const rl = createInterface({
+    input: process.stdin,
+    output: process.stderr,
+  })
+  return new Promise((resolve) => {
+    rl.question(question, (answer) => {
+      rl.close()
+      resolve(answer)
+    })
+  })
+}
+
+async function resolveField(
+  flagValue: string | undefined,
+  promptQuestion: string,
+  flagName: string,
+): Promise<string> {
+  if (flagValue !== undefined) {
+    return flagValue
+  }
+  if (process.stdin.isTTY) {
+    return promptForInput(promptQuestion)
+  }
+  throw new Error(`Missing required: ${flagName} (or run interactively)`)
+}
+
+const config = new Command('config').description('Manage 2kc configuration')
+
+config
+  .command('init')
+  .description('Create configuration file with Discord settings')
+  .option('--webhook-url <url>', 'Discord webhook URL')
+  .option('--bot-token <token>', 'Discord bot token')
+  .option('--channel-id <id>', 'Discord channel ID')
+  .option('--default-require-approval', 'Require approval by default', false)
+  .option('--approval-timeout <ms>', 'Approval timeout in ms', '300000')
+  .action(
+    async (opts: {
+      webhookUrl?: string
+      botToken?: string
+      channelId?: string
+      defaultRequireApproval: boolean
+      approvalTimeout: string
+    }) => {
+      const webhookUrl = await resolveField(
+        opts.webhookUrl,
+        'Discord webhook URL: ',
+        '--webhook-url',
+      )
+      const botToken = await resolveField(opts.botToken, 'Discord bot token: ', '--bot-token')
+      const channelId = await resolveField(opts.channelId, 'Discord channel ID: ', '--channel-id')
+
+      const appConfig: AppConfig = {
+        discord: {
+          webhookUrl,
+          botToken,
+          channelId,
+        },
+        requireApproval: {},
+        defaultRequireApproval: opts.defaultRequireApproval,
+        approvalTimeoutMs: parseInt(opts.approvalTimeout, 10),
+      }
+
+      if (Number.isNaN(appConfig.approvalTimeoutMs) || appConfig.approvalTimeoutMs <= 0) {
+        console.error('Invalid --approval-timeout: must be a positive integer (milliseconds)')
+        process.exitCode = 1
+        return
+      }
+
+      saveConfig(appConfig)
+      console.log(`Config saved to ${CONFIG_PATH}`)
+    },
+  )
+
+config
+  .command('show')
+  .description('Display current configuration (sensitive values redacted)')
+  .action(() => {
+    let appConfig: AppConfig
+    try {
+      appConfig = loadConfig()
+    } catch {
+      console.error('No config found. Run: 2kc config init')
+      process.exitCode = 1
+      return
+    }
+
+    const redacted = {
+      ...appConfig,
+      discord: {
+        ...appConfig.discord,
+        botToken:
+          appConfig.discord.botToken.length > 4
+            ? appConfig.discord.botToken.slice(0, 4) + '...'
+            : appConfig.discord.botToken,
+        webhookUrl:
+          appConfig.discord.webhookUrl.length > 20
+            ? appConfig.discord.webhookUrl.slice(0, 20) + '...'
+            : appConfig.discord.webhookUrl,
+      },
+    }
+
+    console.log(JSON.stringify(redacted, null, 2))
+  })
+
+export { config as configCommand }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -4,6 +4,8 @@ import { Command } from 'commander'
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 
+import { configCommand } from './config.js'
+import { requestCommand } from './request.js'
 import { secretsCommand } from './secrets.js'
 
 const pkg = JSON.parse(
@@ -18,5 +20,7 @@ program
   .version(pkg.version)
 
 program.addCommand(secretsCommand)
+program.addCommand(configCommand)
+program.addCommand(requestCommand)
 
 program.parse()

--- a/src/cli/request.ts
+++ b/src/cli/request.ts
@@ -1,0 +1,143 @@
+import { Command } from 'commander'
+
+import { loadConfig } from '../core/config.js'
+import { SecretStore } from '../core/secret-store.js'
+import { DiscordChannel } from '../channels/discord.js'
+import { WorkflowEngine } from '../core/workflow.js'
+import { GrantManager } from '../core/grant.js'
+import { SecretInjector } from '../core/injector.js'
+import { createAccessRequest } from '../core/request.js'
+import type { NotificationChannel } from '../channels/channel.js'
+
+async function auditLog(channel: NotificationChannel, message: string): Promise<void> {
+  try {
+    await channel.sendNotification(message)
+  } catch (err: unknown) {
+    const errorMessage = err instanceof Error ? err.message : String(err)
+    console.error(`[audit] Warning: failed to send audit log: ${errorMessage}`)
+  }
+}
+
+function formatAuditMessage(requestId: string, event: string, details: string): string {
+  return `[2kc] [${new Date().toISOString()}] [${requestId}] ${event}: ${details}`
+}
+
+const request = new Command('request')
+  .description('Request access to a secret and inject into a command')
+  .argument('<uuid>', 'UUID of the secret to access')
+  .requiredOption('--reason <reason>', 'Justification for access')
+  .requiredOption('--task <taskRef>', 'Task reference (e.g., ticket ID)')
+  .option('--duration <seconds>', 'Grant duration in seconds', '300')
+  .requiredOption('--env <varName>', 'Environment variable name for injection')
+  .requiredOption('--cmd <command>', 'Command to run with secret injected')
+  .action(
+    async (
+      uuid: string,
+      opts: {
+        reason: string
+        task: string
+        duration: string
+        env: string
+        cmd: string
+      },
+    ) => {
+      try {
+        // 1. Load config
+        let config
+        try {
+          config = loadConfig()
+        } catch (err: unknown) {
+          if (err instanceof Error && err.message.includes('Config file not found')) {
+            console.error('Config not found. Run: 2kc config init')
+            process.exitCode = 1
+            return
+          }
+          throw err
+        }
+
+        // 2. Instantiate components
+        const store = new SecretStore()
+        const channel = new DiscordChannel(config.discord)
+        const grantManager = new GrantManager()
+        const injector = new SecretInjector(grantManager, store)
+
+        // 3. Create access request
+        const durationSeconds = parseInt(opts.duration, 10)
+        if (Number.isNaN(durationSeconds) || durationSeconds <= 0) {
+          console.error('Invalid --duration: must be a positive integer (seconds)')
+          process.exitCode = 1
+          return
+        }
+
+        const accessRequest = createAccessRequest(uuid, opts.reason, opts.task, durationSeconds)
+        await auditLog(
+          channel,
+          formatAuditMessage(
+            accessRequest.id,
+            'Request created',
+            `uuid=${uuid}, reason="${opts.reason}", task="${opts.task}", duration=${opts.duration}s`,
+          ),
+        )
+
+        // 4. Process approval workflow
+        const engine = new WorkflowEngine({ store, channel, config })
+        const result = await engine.processRequest(accessRequest)
+        await auditLog(
+          channel,
+          formatAuditMessage(
+            accessRequest.id,
+            `Approval ${result}`,
+            `uuid=${uuid}, result=${result}`,
+          ),
+        )
+
+        if (result !== 'approved') {
+          console.error(`Access request ${result}: ${uuid}`)
+          process.exitCode = 1
+          return
+        }
+
+        // 5. Create grant
+        const grant = grantManager.createGrant(accessRequest)
+
+        // 6. Inject secret and run command
+        const command = ['sh', '-c', opts.cmd]
+        await auditLog(
+          channel,
+          formatAuditMessage(
+            accessRequest.id,
+            'Secret injected',
+            `uuid=${uuid}, env=${opts.env}, command="${opts.cmd}"`,
+          ),
+        )
+
+        const processResult = await injector.inject(grant.id, opts.env, command)
+
+        await auditLog(
+          channel,
+          formatAuditMessage(accessRequest.id, 'Grant used', `grantId=${grant.id}, uuid=${uuid}`),
+        )
+
+        // 7. Output result
+        if (processResult.stdout) process.stdout.write(processResult.stdout)
+        if (processResult.stderr) process.stderr.write(processResult.stderr)
+        // Map null exit code (signal-killed processes) to exit code 1 intentionally,
+        // so the CLI always reports a non-zero exit when the child did not exit cleanly.
+        process.exitCode = processResult.exitCode ?? 1
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err)
+
+        if (message.includes('not found')) {
+          console.error(`Secret UUID not found: ${uuid}`)
+        } else if (message.includes('Grant is not valid')) {
+          console.error(`Grant expired: ${uuid}`)
+        } else {
+          console.error(`Error: ${message}`)
+        }
+
+        process.exitCode = 1
+      }
+    },
+  )
+
+export { request as requestCommand }

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -1,5 +1,5 @@
-import { readFileSync } from 'node:fs'
-import { resolve } from 'node:path'
+import { readFileSync, writeFileSync, mkdirSync, chmodSync } from 'node:fs'
+import { resolve, dirname } from 'node:path'
 import { homedir } from 'node:os'
 
 export interface DiscordConfig {
@@ -15,7 +15,7 @@ export interface AppConfig {
   approvalTimeoutMs: number
 }
 
-const CONFIG_PATH = resolve(homedir(), '.2kc', 'config.json')
+export const CONFIG_PATH = resolve(homedir(), '.2kc', 'config.json')
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
@@ -92,4 +92,11 @@ export function loadConfig(configPath: string = CONFIG_PATH): AppConfig {
   }
 
   return parseConfig(parsed)
+}
+
+export function saveConfig(config: AppConfig, configPath: string = CONFIG_PATH): void {
+  const dir = dirname(configPath)
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(configPath, JSON.stringify(config, null, 2), 'utf-8')
+  chmodSync(configPath, 0o600)
 }


### PR DESCRIPTION
Fixes #9

## End-to-end CLI integration & audit logging

## Summary

Wire the full request-to-injection flow into the CLI and add audit logging that sends all access events to Discord.

## Context

This is the integration issue that brings all components together into a working end-to-end system. It also adds audit logging to Discord, fulfilling the ROADMAP requirement that "Discord logs show request and approval status."

## Acceptance Criteria

### CLI Commands
- [ ] `2kc request <uuid> --reason "..." --task "..." [--duration 300] --env VAR_NAME --cmd "command args"` — full flow: create request → approval → grant → inject → purge
- [ ] `2kc config init` — creates `~/.2kc/config.json` with prompts for Discord webhook URL, bot token, channel ID
- [ ] `2kc config show` — displays current config (redacts sensitive values)
- [ ] Error messages are clear and actionable (e.g., "Secret UUID not found", "Approval denied", "Grant expired")

### Audit Logging
- [ ] All events logged to Discord via `NotificationChannel.sendNotification()`:
  - Request created (who, what UUID, why, task ref)
  - Approval granted / denied / timed out
  - Secret injected (UUID, env var name, command — NOT the secret value)
  - Grant expired
- [ ] Logs include timestamps and request IDs for traceability

### Validation Checklist (from ROADMAP)
- [ ] AI cannot directly access secret database (only UUIDs visible via `2kc secrets list`)
- [ ] All requests require justification (reason + task ref)
- [ ] Tagged secrets require Discord approval
- [ ] Access expires after time limit
- [ ] Secret is not printed in logs or output
- [ ] Discord logs show request and approval status
- [ ] Attempt to list secrets → only UUIDs visible
- [ ] Attempt to reuse expired access → denied

## Dependencies

- Issue: Ephemeral secret injection into process environment (#8)

## Scope Boundaries

- Does NOT include persistent log storage (Discord is the log sink for v0.5)
- Does NOT include a daemon mode — all operations are one-shot CLI invocations
- Does NOT include honeytoken, rate limiting, or anomaly detection (post-MVP)

---
*This PR was created automatically by iloom.*