### PR TITLE
Add configuration system with mode selection

### DIFF
--- a/src/__tests__/config-command.test.ts
+++ b/src/__tests__/config-command.test.ts
@@ -23,6 +23,9 @@ const mockChmodSync = vi.mocked(chmodSync)
 
 function createValidConfig(overrides?: Partial<AppConfig>): AppConfig {
   return {
+    mode: 'standalone',
+    server: { host: '127.0.0.1', port: 2274 },
+    store: { path: '~/.2kc/secrets.json' },
     discord: {
       webhookUrl: 'https://discord.com/api/webhooks/123/abc',
       botToken: 'bot-token-1234567890',
@@ -71,7 +74,77 @@ describe('config init action', () => {
     vi.restoreAllMocks()
   })
 
-  it('accepts all values via flags (non-interactive)', async () => {
+  it('creates config with mode=standalone by default', async () => {
+    const { configCommand } = await import('../cli/config.js')
+
+    await configCommand.parseAsync(['init'], { from: 'user' })
+
+    expect(mockWriteFileSync).toHaveBeenCalledOnce()
+    const writtenJson = mockWriteFileSync.mock.calls[0][1] as string
+    const writtenConfig = JSON.parse(writtenJson) as AppConfig
+    expect(writtenConfig.mode).toBe('standalone')
+    expect(writtenConfig.server).toEqual({ host: '127.0.0.1', port: 2274 })
+    expect(writtenConfig.store).toEqual({ path: '~/.2kc/secrets.json' })
+  })
+
+  it('accepts --mode client flag', async () => {
+    const { configCommand } = await import('../cli/config.js')
+
+    await configCommand.parseAsync(['init', '--mode', 'client'], { from: 'user' })
+
+    const writtenJson = mockWriteFileSync.mock.calls[0][1] as string
+    const writtenConfig = JSON.parse(writtenJson) as AppConfig
+    expect(writtenConfig.mode).toBe('client')
+  })
+
+  it('accepts --server-host and --server-port flags', async () => {
+    const { configCommand } = await import('../cli/config.js')
+
+    await configCommand.parseAsync(
+      ['init', '--server-host', '192.168.1.1', '--server-port', '8080'],
+      { from: 'user' },
+    )
+
+    const writtenJson = mockWriteFileSync.mock.calls[0][1] as string
+    const writtenConfig = JSON.parse(writtenJson) as AppConfig
+    expect(writtenConfig.server.host).toBe('192.168.1.1')
+    expect(writtenConfig.server.port).toBe(8080)
+  })
+
+  it('accepts --server-auth-token flag', async () => {
+    const { configCommand } = await import('../cli/config.js')
+
+    await configCommand.parseAsync(['init', '--server-auth-token', 'my-secret'], { from: 'user' })
+
+    const writtenJson = mockWriteFileSync.mock.calls[0][1] as string
+    const writtenConfig = JSON.parse(writtenJson) as AppConfig
+    expect(writtenConfig.server.authToken).toBe('my-secret')
+  })
+
+  it('accepts --store-path flag', async () => {
+    const { configCommand } = await import('../cli/config.js')
+
+    await configCommand.parseAsync(['init', '--store-path', '/custom/secrets.json'], {
+      from: 'user',
+    })
+
+    const writtenJson = mockWriteFileSync.mock.calls[0][1] as string
+    const writtenConfig = JSON.parse(writtenJson) as AppConfig
+    expect(writtenConfig.store.path).toBe('/custom/secrets.json')
+  })
+
+  it('allows init without discord flags (all optional now)', async () => {
+    const { configCommand } = await import('../cli/config.js')
+
+    await configCommand.parseAsync(['init'], { from: 'user' })
+
+    expect(mockWriteFileSync).toHaveBeenCalledOnce()
+    const writtenJson = mockWriteFileSync.mock.calls[0][1] as string
+    const writtenConfig = JSON.parse(writtenJson) as AppConfig
+    expect(writtenConfig.discord).toBeUndefined()
+  })
+
+  it('accepts all discord values via flags', async () => {
     const { configCommand } = await import('../cli/config.js')
 
     await configCommand.parseAsync(
@@ -90,26 +163,17 @@ describe('config init action', () => {
     expect(mockWriteFileSync).toHaveBeenCalledOnce()
     const writtenJson = mockWriteFileSync.mock.calls[0][1] as string
     const writtenConfig = JSON.parse(writtenJson) as AppConfig
-    expect(writtenConfig.discord.webhookUrl).toBe('https://discord.com/api/webhooks/999/xyz')
-    expect(writtenConfig.discord.botToken).toBe('my-bot-token')
-    expect(writtenConfig.discord.channelId).toBe('112233')
+    expect(writtenConfig.discord).toEqual({
+      webhookUrl: 'https://discord.com/api/webhooks/999/xyz',
+      botToken: 'my-bot-token',
+      channelId: '112233',
+    })
   })
 
   it('uses defaults for approvalTimeoutMs and defaultRequireApproval when not provided', async () => {
     const { configCommand } = await import('../cli/config.js')
 
-    await configCommand.parseAsync(
-      [
-        'init',
-        '--webhook-url',
-        'https://discord.com/api/webhooks/999/xyz',
-        '--bot-token',
-        'my-bot-token',
-        '--channel-id',
-        '112233',
-      ],
-      { from: 'user' },
-    )
+    await configCommand.parseAsync(['init'], { from: 'user' })
 
     const writtenJson = mockWriteFileSync.mock.calls[0][1] as string
     const writtenConfig = JSON.parse(writtenJson) as AppConfig
@@ -117,12 +181,22 @@ describe('config init action', () => {
     expect(writtenConfig.approvalTimeoutMs).toBe(300_000)
   })
 
-  it('calls saveConfig with correct AppConfig shape', async () => {
+  it('calls saveConfig with correct AppConfig shape (full config)', async () => {
     const { configCommand } = await import('../cli/config.js')
 
     await configCommand.parseAsync(
       [
         'init',
+        '--mode',
+        'client',
+        '--server-host',
+        '10.0.0.1',
+        '--server-port',
+        '3000',
+        '--server-auth-token',
+        'tok123',
+        '--store-path',
+        '/my/store.json',
         '--webhook-url',
         'https://discord.com/api/webhooks/999/xyz',
         '--bot-token',
@@ -138,6 +212,9 @@ describe('config init action', () => {
     const writtenJson = mockWriteFileSync.mock.calls[0][1] as string
     const writtenConfig = JSON.parse(writtenJson) as AppConfig
     expect(writtenConfig).toEqual({
+      mode: 'client',
+      server: { host: '10.0.0.1', port: 3000, authToken: 'tok123' },
+      store: { path: '/my/store.json' },
       discord: {
         webhookUrl: 'https://discord.com/api/webhooks/999/xyz',
         botToken: 'my-bot-token',
@@ -155,7 +232,7 @@ describe('config show action', () => {
     vi.restoreAllMocks()
   })
 
-  it('loads and displays config', async () => {
+  it('displays mode, server, and store fields', async () => {
     const config = createValidConfig()
     mockReadFileSync.mockReturnValue(JSON.stringify(config))
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
@@ -165,6 +242,9 @@ describe('config show action', () => {
 
     expect(logSpy).toHaveBeenCalledOnce()
     const output = JSON.parse(logSpy.mock.calls[0][0] as string) as Record<string, unknown>
+    expect(output).toHaveProperty('mode', 'standalone')
+    expect(output).toHaveProperty('server')
+    expect(output).toHaveProperty('store')
     expect(output).toHaveProperty('discord')
   })
 
@@ -208,20 +288,47 @@ describe('config show action', () => {
     expect(output.discord.webhookUrl).toBe('https://discord.com/...')
   })
 
-  it('errors with actionable message when config file missing', async () => {
+  it('redacts server.authToken', async () => {
+    const config = createValidConfig({
+      server: { host: '127.0.0.1', port: 2274, authToken: 'super-secret-token' },
+    })
+    mockReadFileSync.mockReturnValue(JSON.stringify(config))
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    const { configCommand } = await import('../cli/config.js')
+    await configCommand.parseAsync(['show'], { from: 'user' })
+
+    const output = JSON.parse(logSpy.mock.calls[0][0] as string) as {
+      server: { authToken: string }
+    }
+    expect(output.server.authToken).toBe('supe...')
+  })
+
+  it('shows config with defaults when file is missing (standalone mode)', async () => {
     const err = new Error('ENOENT') as NodeJS.ErrnoException
     err.code = 'ENOENT'
     mockReadFileSync.mockImplementation(() => {
       throw err
     })
-    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
 
     const { configCommand } = await import('../cli/config.js')
-    const savedExitCode = process.exitCode
     await configCommand.parseAsync(['show'], { from: 'user' })
 
-    expect(errorSpy).toHaveBeenCalledWith('No config found. Run: 2kc config init')
-    expect(process.exitCode).toBe(1)
-    process.exitCode = savedExitCode
+    expect(logSpy).toHaveBeenCalledOnce()
+    const output = JSON.parse(logSpy.mock.calls[0][0] as string) as Record<string, unknown>
+    expect(output).toHaveProperty('mode', 'standalone')
+  })
+
+  it('shows store.path field', async () => {
+    const config = createValidConfig()
+    mockReadFileSync.mockReturnValue(JSON.stringify(config))
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    const { configCommand } = await import('../cli/config.js')
+    await configCommand.parseAsync(['show'], { from: 'user' })
+
+    const output = JSON.parse(logSpy.mock.calls[0][0] as string) as { store: { path: string } }
+    expect(output.store).toHaveProperty('path')
   })
 })

--- a/src/__tests__/request-command.test.ts
+++ b/src/__tests__/request-command.test.ts
@@ -71,6 +71,9 @@ vi.mock('../core/request.js', () => ({
 
 function createTestConfig(): AppConfig {
   return {
+    mode: 'standalone',
+    server: { host: '127.0.0.1', port: 2274 },
+    store: { path: '~/.2kc/secrets.json' },
     discord: {
       webhookUrl: 'https://discord.com/api/webhooks/123/abc',
       botToken: 'bot-token-123',
@@ -206,14 +209,15 @@ describe('request command orchestration', () => {
     errorSpy.mockRestore()
   })
 
-  it('config file missing: prints actionable error pointing to "2kc config init"', async () => {
-    const configError = new Error('Config file not found: /path/to/config.json')
-    mockLoadConfig.mockImplementation(() => {
-      throw configError
+  it('discord not configured: prints actionable error pointing to "2kc config init"', async () => {
+    mockLoadConfig.mockReturnValue({
+      ...createTestConfig(),
+      discord: undefined,
     })
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
     await runRequest()
 
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Discord not configured'))
     expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('config init'))
     expect(process.exitCode).toBe(1)
     errorSpy.mockRestore()

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -1,76 +1,76 @@
 import { Command } from 'commander'
-import { createInterface } from 'node:readline'
 
 import { loadConfig, saveConfig, CONFIG_PATH, type AppConfig } from '../core/config.js'
-
-function promptForInput(question: string): Promise<string> {
-  const rl = createInterface({
-    input: process.stdin,
-    output: process.stderr,
-  })
-  return new Promise((resolve) => {
-    rl.question(question, (answer) => {
-      rl.close()
-      resolve(answer)
-    })
-  })
-}
-
-async function resolveField(
-  flagValue: string | undefined,
-  promptQuestion: string,
-  flagName: string,
-): Promise<string> {
-  if (flagValue !== undefined) {
-    return flagValue
-  }
-  if (process.stdin.isTTY) {
-    return promptForInput(promptQuestion)
-  }
-  throw new Error(`Missing required: ${flagName} (or run interactively)`)
-}
 
 const config = new Command('config').description('Manage 2kc configuration')
 
 config
   .command('init')
-  .description('Create configuration file with Discord settings')
+  .description('Create configuration file')
+  .option('--mode <mode>', 'Operating mode (standalone or client)', 'standalone')
+  .option('--server-host <host>', 'Server host', '127.0.0.1')
+  .option('--server-port <port>', 'Server port', '2274')
+  .option('--server-auth-token <token>', 'Server auth token')
+  .option('--store-path <path>', 'Secret store path', '~/.2kc/secrets.json')
   .option('--webhook-url <url>', 'Discord webhook URL')
   .option('--bot-token <token>', 'Discord bot token')
   .option('--channel-id <id>', 'Discord channel ID')
   .option('--default-require-approval', 'Require approval by default', false)
   .option('--approval-timeout <ms>', 'Approval timeout in ms', '300000')
   .action(
-    async (opts: {
+    (opts: {
+      mode: string
+      serverHost: string
+      serverPort: string
+      serverAuthToken?: string
+      storePath: string
       webhookUrl?: string
       botToken?: string
       channelId?: string
       defaultRequireApproval: boolean
       approvalTimeout: string
     }) => {
-      const webhookUrl = await resolveField(
-        opts.webhookUrl,
-        'Discord webhook URL: ',
-        '--webhook-url',
-      )
-      const botToken = await resolveField(opts.botToken, 'Discord bot token: ', '--bot-token')
-      const channelId = await resolveField(opts.channelId, 'Discord channel ID: ', '--channel-id')
-
-      const appConfig: AppConfig = {
-        discord: {
-          webhookUrl,
-          botToken,
-          channelId,
-        },
-        requireApproval: {},
-        defaultRequireApproval: opts.defaultRequireApproval,
-        approvalTimeoutMs: parseInt(opts.approvalTimeout, 10),
+      if (opts.mode !== 'standalone' && opts.mode !== 'client') {
+        console.error('Invalid --mode: must be "standalone" or "client"')
+        process.exitCode = 1
+        return
       }
 
-      if (Number.isNaN(appConfig.approvalTimeoutMs) || appConfig.approvalTimeoutMs <= 0) {
+      const port = parseInt(opts.serverPort, 10)
+      if (Number.isNaN(port) || port < 1 || port > 65535) {
+        console.error('Invalid --server-port: must be an integer between 1 and 65535')
+        process.exitCode = 1
+        return
+      }
+
+      const approvalTimeoutMs = parseInt(opts.approvalTimeout, 10)
+      if (Number.isNaN(approvalTimeoutMs) || approvalTimeoutMs <= 0) {
         console.error('Invalid --approval-timeout: must be a positive integer (milliseconds)')
         process.exitCode = 1
         return
+      }
+
+      const appConfig: AppConfig = {
+        mode: opts.mode,
+        server: {
+          host: opts.serverHost,
+          port,
+          ...(opts.serverAuthToken !== undefined ? { authToken: opts.serverAuthToken } : {}),
+        },
+        store: {
+          path: opts.storePath,
+        },
+        discord:
+          opts.webhookUrl && opts.botToken && opts.channelId
+            ? {
+                webhookUrl: opts.webhookUrl,
+                botToken: opts.botToken,
+                channelId: opts.channelId,
+              }
+            : undefined,
+        requireApproval: {},
+        defaultRequireApproval: opts.defaultRequireApproval,
+        approvalTimeoutMs,
       }
 
       saveConfig(appConfig)
@@ -82,18 +82,29 @@ config
   .command('show')
   .description('Display current configuration (sensitive values redacted)')
   .action(() => {
-    let appConfig: AppConfig
-    try {
-      appConfig = loadConfig()
-    } catch {
-      console.error('No config found. Run: 2kc config init')
-      process.exitCode = 1
-      return
+    const appConfig = loadConfig()
+
+    const redacted: Record<string, unknown> = {
+      mode: appConfig.mode,
+      server: {
+        ...appConfig.server,
+        ...(appConfig.server.authToken
+          ? {
+              authToken:
+                appConfig.server.authToken.length > 4
+                  ? appConfig.server.authToken.slice(0, 4) + '...'
+                  : appConfig.server.authToken,
+            }
+          : {}),
+      },
+      store: appConfig.store,
+      requireApproval: appConfig.requireApproval,
+      defaultRequireApproval: appConfig.defaultRequireApproval,
+      approvalTimeoutMs: appConfig.approvalTimeoutMs,
     }
 
-    const redacted = {
-      ...appConfig,
-      discord: {
+    if (appConfig.discord) {
+      redacted.discord = {
         ...appConfig.discord,
         botToken:
           appConfig.discord.botToken.length > 4
@@ -103,7 +114,7 @@ config
           appConfig.discord.webhookUrl.length > 20
             ? appConfig.discord.webhookUrl.slice(0, 20) + '...'
             : appConfig.discord.webhookUrl,
-      },
+      }
     }
 
     console.log(JSON.stringify(redacted, null, 2))


### PR DESCRIPTION
Fixes #15

## Add configuration system with mode selection

## Summary

Implement a configuration loader that reads `~/.2kc/config.json`, validates it, and exposes typed config to the rest of the application. The config determines the operating mode (`standalone` vs `client`) and holds server connection details.

## Context

This is the foundation for the client-server architecture (Epic #14). Every other child issue depends on knowing the current mode and server settings. The config system must also be backwards compatible — if no config file exists, default to `standalone` mode (preserving current behavior).

## Acceptance Criteria

- [ ] `Config` TypeScript interface in `src/core/config.ts` with fields:
  - `mode`: `'standalone' | 'client'` (default: `'standalone'`)
  - `server.host`: string (default: `'127.0.0.1'`)
  - `server.port`: number (default: `2274`)
  - `server.authToken`: string (shared secret for bearer auth)
  - `store.path`: string (default: `'~/.2kc/secrets.json'`)
  - `discord.webhookUrl`: string (optional)
  - `discord.botToken`: string (optional)
  - `discord.channelId`: string (optional)
- [ ] `loadConfig()` function that:
  - Reads `~/.2kc/config.json` if it exists
  - Returns sensible defaults if file is missing (standalone mode)
  - Validates the config shape and throws clear errors on invalid config
  - Resolves `~` in paths
- [ ] `2kc config init` CLI subcommand that creates a default config file with comments
- [ ] `2kc config show` CLI subcommand that prints the current effective config (masking sensitive fields like tokens)
- [ ] Config file is created with `0600` permissions
- [ ] Unit tests for config loading, defaults, validation, and missing file handling

## Dependencies

None (within this epic). Depends on #2 (complete).

## Scope Boundaries

- Does NOT include server startup logic
- Does NOT include client connection logic
- Config schema may be extended by later issues (e.g., adding fields) — keep the loader flexible

---
*This PR was created automatically by iloom.*