### PR TITLE
Add bearer token auth middleware to server

### DIFF
--- a/.iloom/settings.json
+++ b/.iloom/settings.json
@@ -1,0 +1,7 @@
+{
+  "mainBranch": "main",
+  "mergeBehavior": {
+    "mode": "github-draft-pr",
+    "autoCommitPush": true
+  }
+}

--- a/src/cli/server.ts
+++ b/src/cli/server.ts
@@ -1,4 +1,5 @@
 import { Command } from 'commander'
+import { randomBytes } from 'node:crypto'
 import { fork } from 'node:child_process'
 import http from 'node:http'
 import { resolve, dirname } from 'node:path'
@@ -168,5 +169,16 @@ server
       )
     }
   })
+
+const token = new Command('token').description('Manage server authentication tokens')
+
+token
+  .command('generate')
+  .description('Generate a random 32-byte hex token for server authentication')
+  .action(() => {
+    console.log(randomBytes(32).toString('hex'))
+  })
+
+server.addCommand(token)
 
 export { server as serverCommand }


### PR DESCRIPTION
Fixes #18

## Add bearer token auth middleware to server

## Summary

Implement a Fastify plugin that authenticates incoming API requests using a bearer token (shared secret from config). Unauthenticated requests are rejected with 401.

## Context

The server API must be protected so only authorized clients can access it (Epic #14). A shared bearer token is the simplest auth mechanism that works for local and trusted-network scenarios. The token is configured in `~/.2kc/config.json` on both server and client sides.

## Acceptance Criteria

- [ ] Fastify plugin in `src/server/auth.ts` that:
  - Reads the expected token from `config.server.authToken`
  - Uses a `preHandler` hook to check `Authorization: Bearer <token>` header on all routes except `GET /health`
  - Returns `401 Unauthorized` with `{ error: 'Invalid or missing auth token' }` on failure
  - Passes through on valid token
- [ ] Timing-safe comparison for token validation (use `crypto.timingSafeEqual`)
- [ ] If `config.server.authToken` is not set, server refuses to start with a clear error message
- [ ] `2kc server token generate` CLI subcommand that generates a random 32-byte hex token and prints it (user copies into config)
- [ ] Unit tests:
  - Request with valid token passes
  - Request with invalid token returns 401
  - Request with no Authorization header returns 401
  - Health endpoint works without auth

## Dependencies

- #17 (HTTP server foundation) — needs the Fastify server to attach the plugin to

## Scope Boundaries

- Does NOT include per-user auth, RBAC, or token rotation
- Does NOT include TLS (can be added later or handled by a reverse proxy)
- Single shared secret only — this is sufficient for v0.5

---
*This PR was created automatically by iloom.*