### PR TITLE
Add `ref` field to SecretEntry and support ref-based lookups

### DIFF
--- a/src/__tests__/remote-service.test.ts
+++ b/src/__tests__/remote-service.test.ts
@@ -77,7 +77,7 @@ describe('RemoteService', () => {
       )
     })
 
-    it('add() calls POST /api/secrets with name, value, tags', async () => {
+    it('add() calls POST /api/secrets with ref, value, tags', async () => {
       const fetchMock = mockFetchResponse(200, { uuid: 'new-uuid' })
       globalThis.fetch = fetchMock
 
@@ -89,7 +89,7 @@ describe('RemoteService', () => {
         'http://127.0.0.1:2274/api/secrets',
         expect.objectContaining({
           method: 'POST',
-          body: JSON.stringify({ name: 'my-secret', value: 's3cret', tags: ['tag1'] }),
+          body: JSON.stringify({ ref: 'my-secret', value: 's3cret', tags: ['tag1'] }),
         }),
       )
     })
@@ -108,7 +108,7 @@ describe('RemoteService', () => {
     })
 
     it('getMetadata() calls GET /api/secrets/:uuid', async () => {
-      const metadata = { uuid: 'x', name: 'n', tags: [] }
+      const metadata = { uuid: 'x', ref: 'n', tags: [] }
       const fetchMock = mockFetchResponse(200, metadata)
       globalThis.fetch = fetchMock
 

--- a/src/__tests__/secret-store.test.ts
+++ b/src/__tests__/secret-store.test.ts
@@ -28,10 +28,10 @@ describe('SecretStore', () => {
       expect(uuid).toMatch(UUID_V4_REGEX)
     })
 
-    it('should store name, value, tags, createdAt, updatedAt', () => {
+    it('should store ref, value, tags, createdAt, updatedAt', () => {
       const uuid = store.add('my-secret', 's3cret', ['api', 'prod'])
       const metadata = store.getMetadata(uuid)
-      expect(metadata.name).toBe('my-secret')
+      expect(metadata.ref).toBe('my-secret')
       expect(metadata.tags).toEqual(['api', 'prod'])
       expect(store.getValue(uuid)).toBe('s3cret')
     })
@@ -48,29 +48,79 @@ describe('SecretStore', () => {
       expect(uuid.length).toBeGreaterThan(0)
     })
 
-    it('should throw when adding a secret with a duplicate name', () => {
+    it('should throw when adding a secret with a duplicate ref', () => {
       store.add('my-secret', 'value1')
       expect(() => store.add('my-secret', 'value2')).toThrow(
-        'A secret with the name "my-secret" already exists',
+        'A secret with the ref "my-secret" already exists',
       )
     })
 
-    it('should allow different names', () => {
+    it('should allow different refs', () => {
       store.add('secret-a', 'value1')
       const uuid = store.add('secret-b', 'value2')
       expect(uuid).toMatch(UUID_V4_REGEX)
     })
   })
 
+  describe('ref validation', () => {
+    it('should reject refs with uppercase letters', () => {
+      expect(() => store.add('My-Secret', 'value')).toThrow('Invalid ref')
+    })
+
+    it('should reject refs with leading hyphens', () => {
+      expect(() => store.add('-my-secret', 'value')).toThrow('Invalid ref')
+    })
+
+    it('should reject refs with trailing hyphens', () => {
+      expect(() => store.add('my-secret-', 'value')).toThrow('Invalid ref')
+    })
+
+    it('should reject empty string ref', () => {
+      expect(() => store.add('', 'value')).toThrow('Invalid ref')
+    })
+
+    it('should reject refs with special characters (spaces, underscores, etc.)', () => {
+      expect(() => store.add('my secret', 'value')).toThrow('Invalid ref')
+      expect(() => store.add('my_secret', 'value')).toThrow('Invalid ref')
+      expect(() => store.add('my@secret', 'value')).toThrow('Invalid ref')
+    })
+
+    it('should accept valid slug like "my-api-key"', () => {
+      const uuid = store.add('my-api-key', 'value')
+      expect(uuid).toMatch(UUID_V4_REGEX)
+    })
+
+    it('should accept single character ref like "a"', () => {
+      const uuid = store.add('a', 'value')
+      expect(uuid).toMatch(UUID_V4_REGEX)
+    })
+
+    it('should accept two character ref like "ab"', () => {
+      const uuid = store.add('ab', 'value')
+      expect(uuid).toMatch(UUID_V4_REGEX)
+    })
+
+    it('should accept numeric refs', () => {
+      const uuid = store.add('123', 'value')
+      expect(uuid).toMatch(UUID_V4_REGEX)
+    })
+
+    it('should reject refs that look like UUIDs', () => {
+      expect(() => store.add('550e8400-e29b-41d4-a716-446655440000', 'value')).toThrow(
+        'Refs must not look like UUIDs',
+      )
+    })
+  })
+
   describe('list', () => {
-    it('should return only uuid and tags for each secret', () => {
+    it('should return uuid, ref, and tags for each secret', () => {
       store.add('secret-1', 'val1', ['tag-a'])
       store.add('secret-2', 'val2', ['tag-b'])
 
       const items = store.list()
       expect(items).toHaveLength(2)
       for (const item of items) {
-        expect(Object.keys(item).sort()).toEqual(['tags', 'uuid'])
+        expect(Object.keys(item).sort()).toEqual(['ref', 'tags', 'uuid'])
       }
     })
 
@@ -97,13 +147,13 @@ describe('SecretStore', () => {
   })
 
   describe('getMetadata', () => {
-    it('should return uuid, tags, and name but NOT value', () => {
+    it('should return uuid, tags, and ref but NOT value', () => {
       const uuid = store.add('my-secret', 's3cret', ['tag1'])
       const metadata = store.getMetadata(uuid)
 
       expect(metadata).toEqual({
         uuid,
-        name: 'my-secret',
+        ref: 'my-secret',
         tags: ['tag1'],
       })
       expect(metadata).not.toHaveProperty('value')
@@ -125,6 +175,73 @@ describe('SecretStore', () => {
     it('should throw for non-existent UUID', () => {
       expect(() => store.getValue('non-existent-uuid')).toThrow(
         'Secret with UUID non-existent-uuid not found',
+      )
+    })
+  })
+
+  describe('getByRef', () => {
+    it('should return metadata for existing ref', () => {
+      const uuid = store.add('my-api-key', 'secret-value', ['prod'])
+      const metadata = store.getByRef('my-api-key')
+
+      expect(metadata).toEqual({
+        uuid,
+        ref: 'my-api-key',
+        tags: ['prod'],
+      })
+      expect(metadata).not.toHaveProperty('value')
+    })
+
+    it('should throw for non-existent ref', () => {
+      expect(() => store.getByRef('does-not-exist')).toThrow(
+        'Secret with ref "does-not-exist" not found',
+      )
+    })
+  })
+
+  describe('getValueByRef', () => {
+    it('should return value for existing ref', () => {
+      store.add('my-api-key', 'secret-value')
+      expect(store.getValueByRef('my-api-key')).toBe('secret-value')
+    })
+
+    it('should throw for non-existent ref', () => {
+      expect(() => store.getValueByRef('does-not-exist')).toThrow(
+        'Secret with ref "does-not-exist" not found',
+      )
+    })
+  })
+
+  describe('resolve', () => {
+    it('should resolve a UUID to metadata', () => {
+      const uuid = store.add('my-secret', 'value', ['tag1'])
+      const metadata = store.resolve(uuid)
+
+      expect(metadata).toEqual({
+        uuid,
+        ref: 'my-secret',
+        tags: ['tag1'],
+      })
+    })
+
+    it('should resolve a ref to metadata', () => {
+      const uuid = store.add('my-secret', 'value', ['tag1'])
+      const metadata = store.resolve('my-secret')
+
+      expect(metadata).toEqual({
+        uuid,
+        ref: 'my-secret',
+        tags: ['tag1'],
+      })
+    })
+
+    it('should throw for unknown ref-or-UUID', () => {
+      expect(() => store.resolve('unknown-ref')).toThrow('Secret with ref "unknown-ref" not found')
+    })
+
+    it('should throw for unknown UUID', () => {
+      expect(() => store.resolve('00000000-0000-0000-0000-000000000000')).toThrow(
+        'Secret with UUID 00000000-0000-0000-0000-000000000000 not found',
       )
     })
   })

--- a/src/__tests__/workflow.test.ts
+++ b/src/__tests__/workflow.test.ts
@@ -2,7 +2,8 @@
 
 import { WorkflowEngine } from '../core/workflow.js'
 import type { NotificationChannel } from '../channels/channel.js'
-import type { SecretStore, SecretMetadata } from '../core/secret-store.js'
+import type { SecretStore } from '../core/secret-store.js'
+import type { SecretMetadata } from '../core/types.js'
 import type { AccessRequest } from '../core/request.js'
 import type { AppConfig } from '../core/config.js'
 
@@ -59,7 +60,7 @@ describe('WorkflowEngine', () => {
     it('sends approval request and returns approved when channel approves', async () => {
       const store = createSingleMockStore({
         uuid: 'secret-uuid-1',
-        name: 'db-password',
+        ref: 'db-password',
         tags: ['production'],
       })
       const channel = createMockChannel('approved')
@@ -83,7 +84,7 @@ describe('WorkflowEngine', () => {
     it('sends approval request and returns denied when channel denies', async () => {
       const store = createSingleMockStore({
         uuid: 'secret-uuid-1',
-        name: 'db-password',
+        ref: 'db-password',
         tags: ['production'],
       })
       const channel = createMockChannel('denied')
@@ -100,7 +101,7 @@ describe('WorkflowEngine', () => {
     it('sends approval request and returns timeout when channel times out', async () => {
       const store = createSingleMockStore({
         uuid: 'secret-uuid-1',
-        name: 'db-password',
+        ref: 'db-password',
         tags: ['production'],
       })
       const channel = createMockChannel('timeout')
@@ -116,7 +117,7 @@ describe('WorkflowEngine', () => {
     it('auto-approves when no tags match requireApproval', async () => {
       const store = createSingleMockStore({
         uuid: 'secret-uuid-1',
-        name: 'dev-key',
+        ref: 'dev-key',
         tags: ['dev'],
       })
       const channel = createMockChannel()
@@ -137,7 +138,7 @@ describe('WorkflowEngine', () => {
     it('auto-approves untagged secret when defaultRequireApproval is false', async () => {
       const store = createSingleMockStore({
         uuid: 'secret-uuid-1',
-        name: 'misc-secret',
+        ref: 'misc-secret',
         tags: [],
       })
       const channel = createMockChannel()
@@ -158,7 +159,7 @@ describe('WorkflowEngine', () => {
     it('requires approval for untagged secret when defaultRequireApproval is true', async () => {
       const store = createSingleMockStore({
         uuid: 'secret-uuid-1',
-        name: 'misc-secret',
+        ref: 'misc-secret',
         tags: [],
       })
       const channel = createMockChannel('approved')
@@ -190,7 +191,7 @@ describe('WorkflowEngine', () => {
     it('throws when channel send fails and sets status to denied', async () => {
       const store = createSingleMockStore({
         uuid: 'secret-uuid-1',
-        name: 'db-password',
+        ref: 'db-password',
         tags: ['production'],
       })
       const channel: NotificationChannel = {
@@ -207,7 +208,7 @@ describe('WorkflowEngine', () => {
     it('skips approval when tag explicitly set to false even if default is true', async () => {
       const store = createSingleMockStore({
         uuid: 'secret-uuid-1',
-        name: 'dev-key',
+        ref: 'dev-key',
         tags: ['dev'],
       })
       const channel = createMockChannel()
@@ -232,8 +233,8 @@ describe('WorkflowEngine', () => {
   describe('processRequest - batch', () => {
     it('fetches metadata for all secretUuids', async () => {
       const store = createMockStore({
-        'uuid-1': { uuid: 'uuid-1', name: 'secret-a', tags: ['dev'] },
-        'uuid-2': { uuid: 'uuid-2', name: 'secret-b', tags: ['dev'] },
+        'uuid-1': { uuid: 'uuid-1', ref: 'secret-a', tags: ['dev'] },
+        'uuid-2': { uuid: 'uuid-2', ref: 'secret-b', tags: ['dev'] },
       })
       const channel = createMockChannel()
       const engine = new WorkflowEngine({
@@ -290,8 +291,8 @@ describe('WorkflowEngine', () => {
 
     it('channel request includes all secret names and UUIDs', async () => {
       const store = createMockStore({
-        'uuid-1': { uuid: 'uuid-1', name: 'secret-a', tags: ['production'] },
-        'uuid-2': { uuid: 'uuid-2', name: 'secret-b', tags: ['production'] },
+        'uuid-1': { uuid: 'uuid-1', ref: 'secret-a', tags: ['production'] },
+        'uuid-2': { uuid: 'uuid-2', ref: 'secret-b', tags: ['production'] },
       })
       const channel = createMockChannel('approved')
       const engine = new WorkflowEngine({

--- a/src/core/remote-service.ts
+++ b/src/core/remote-service.ts
@@ -77,12 +77,14 @@ export class RemoteService implements Service {
 
   secrets: Service['secrets'] = {
     list: () => this.request<SecretSummary[]>('GET', '/api/secrets'),
-    add: (name: string, value: string, tags?: string[]) =>
-      this.request<{ uuid: string }>('POST', '/api/secrets', { name, value, tags }),
+    add: (ref: string, value: string, tags?: string[]) =>
+      this.request<{ uuid: string }>('POST', '/api/secrets', { ref, value, tags }),
     remove: (uuid: string) =>
       this.request<void>('DELETE', `/api/secrets/${encodeURIComponent(uuid)}`),
     getMetadata: (uuid: string) =>
       this.request<SecretMetadata>('GET', `/api/secrets/${encodeURIComponent(uuid)}`),
+    resolve: (refOrUuid: string) =>
+      this.request<SecretMetadata>('GET', `/api/secrets/resolve/${encodeURIComponent(refOrUuid)}`),
   }
 
   requests: Service['requests'] = {

--- a/src/core/service.ts
+++ b/src/core/service.ts
@@ -11,9 +11,10 @@ export interface Service {
 
   secrets: {
     list(): Promise<SecretSummary[]>
-    add(name: string, value: string, tags?: string[]): Promise<{ uuid: string }>
+    add(ref: string, value: string, tags?: string[]): Promise<{ uuid: string }>
     remove(uuid: string): Promise<void>
     getMetadata(uuid: string): Promise<SecretMetadata>
+    resolve(refOrUuid: string): Promise<SecretMetadata>
   }
 
   requests: {
@@ -52,6 +53,9 @@ export class LocalService implements Service {
       notImplemented()
     },
     async getMetadata() {
+      notImplemented()
+    },
+    async resolve() {
       notImplemented()
     },
   }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,6 +1,6 @@
 export interface SecretEntry {
   uuid: string
-  name: string
+  ref: string
   value: string
   tags: string[]
   createdAt: string
@@ -9,12 +9,13 @@ export interface SecretEntry {
 
 export interface SecretListItem {
   uuid: string
+  ref: string
   tags: string[]
 }
 
 export interface SecretMetadata {
   uuid: string
-  name: string
+  ref: string
   tags: string[]
 }
 

--- a/src/core/workflow.ts
+++ b/src/core/workflow.ts
@@ -35,7 +35,7 @@ function toChannelRequest(
     requester: 'agent',
     justification: request.reason,
     durationMs: request.durationSeconds * 1000,
-    secretNames: metadataList.map((m) => m.name),
+    secretNames: metadataList.map((m) => m.ref),
   }
 }
 


### PR DESCRIPTION
Fixes #40

## Add `ref` field to SecretEntry and support ref-based lookups

## Summary

Add a human-readable `ref` (reference string) field to `SecretEntry` that serves as an alternative lookup key alongside UUIDs. The `ref` is a unique, URL-safe slug like `perplexity-api-key`.

## Context

Currently secrets are only addressable by UUID, which is cumbersome for humans. Adding a `ref` field allows users to reference secrets by memorable names (e.g., in `2k://` placeholder URIs and CLI commands).

## Implementation Details

### Types (`src/core/types.ts`)
- Rename `name` → `ref` on `SecretEntry` (or add `ref` alongside `name` if backward compat needed)
- `ref` must be a non-empty, URL-safe slug: `[a-z0-9][a-z0-9-]*[a-z0-9]` (lowercase alphanumeric + hyphens, no leading/trailing hyphens)
- Add `ref` to `SecretMetadata` and `SecretListItem`

### SecretStore (`src/core/secret-store.ts`)
- Add `getByRef(ref: string)` method that returns the same shape as `getMetadata(uuid)`
- Add `getValueByRef(ref: string)` (or make `getValue` accept ref or uuid)
- Add a `resolve(refOrUuid: string)` convenience method that determines whether the input is a UUID or ref and returns the `SecretEntry` metadata
- Validate ref uniqueness on `add()` — throw if ref already exists
- Validate ref format on `add()`

### CLI (`src/cli/secrets.ts`)
- Rename `--name` flag to `--ref` on `secrets add`
- Update `secrets list` output to include `ref`
- Allow `secrets remove` to accept ref or UUID

### Tests (`src/__tests__/secret-store.test.ts`)
- Test ref validation (format, uniqueness)
- Test `getByRef()` and `resolve()` lookups
- Test that existing UUID-based lookups still work
- Test rejection of invalid ref formats

## Acceptance Criteria

- [ ] `SecretEntry` has a `ref` field validated as a URL-safe slug
- [ ] `SecretStore.resolve(refOrUuid)` returns metadata for either a ref or UUID input
- [ ] `secrets add --ref my-api-key --value xyz` stores with ref
- [ ] `secrets remove my-api-key` works by ref
- [ ] `secrets list` output includes ref for each entry
- [ ] Duplicate refs are rejected with a clear error
- [ ] All existing tests updated and passing, new tests added

## Dependencies

None — this is foundational for subsequent work.

## Scope Boundaries

- Does NOT change grant or request models (those come in later issues)
- Does NOT modify injection logic
- Does NOT touch server API

---
*This PR was created automatically by iloom.*