### PR TITLE
Add stdout/stderr secret redaction to injector

### DIFF
--- a/src/__tests__/redact.test.ts
+++ b/src/__tests__/redact.test.ts
@@ -1,0 +1,115 @@
+/// <reference types="vitest/globals" />
+
+import { RedactTransform } from '../core/redact.js'
+
+/** Helper: write chunks to a transform, collect output, return as string */
+function collect(transform: RedactTransform, chunks: (string | Buffer)[]): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let result = ''
+    transform.on('data', (data: Buffer | string) => {
+      result += data.toString()
+    })
+    transform.on('end', () => resolve(result))
+    transform.on('error', reject)
+
+    for (const chunk of chunks) {
+      transform.write(typeof chunk === 'string' ? Buffer.from(chunk) : chunk)
+    }
+    transform.end()
+  })
+}
+
+describe('RedactTransform', () => {
+  it('replaces a single secret with [REDACTED]', async () => {
+    const t = new RedactTransform(['my-secret'])
+    const result = await collect(t, ['the value is my-secret here'])
+    expect(result).toBe('the value is [REDACTED] here')
+  })
+
+  it('replaces multiple different secrets', async () => {
+    const t = new RedactTransform(['alpha', 'bravo'])
+    const result = await collect(t, ['alpha and bravo are secrets'])
+    expect(result).toBe('[REDACTED] and [REDACTED] are secrets')
+  })
+
+  it('replaces multiple occurrences of same secret', async () => {
+    const t = new RedactTransform(['tok'])
+    const result = await collect(t, ['tok appears tok twice tok'])
+    expect(result).toBe('[REDACTED] appears [REDACTED] twice [REDACTED]')
+  })
+
+  it('handles secret spanning two chunks', async () => {
+    const t = new RedactTransform(['boundary'])
+    // Split "boundary" across two chunks: "boun" + "dary"
+    const result = await collect(t, ['before boun', 'dary after'])
+    expect(result).toBe('before [REDACTED] after')
+  })
+
+  it('handles secret spanning three chunks', async () => {
+    const t = new RedactTransform(['secret123'])
+    // Split across three chunks
+    const result = await collect(t, ['sec', 'ret1', '23 tail'])
+    expect(result).toBe('[REDACTED] tail')
+  })
+
+  it('passes through data unchanged when secrets list is empty', async () => {
+    const t = new RedactTransform([])
+    const result = await collect(t, ['nothing to redact here'])
+    expect(result).toBe('nothing to redact here')
+  })
+
+  it('passes through data unchanged when no secrets match', async () => {
+    const t = new RedactTransform(['xyz'])
+    const result = await collect(t, ['nothing matches here'])
+    expect(result).toBe('nothing matches here')
+  })
+
+  it('handles secrets containing regex special characters (e.g. $, ., *)', async () => {
+    const t = new RedactTransform(['price$100.00', 'a*b+c?'])
+    const result = await collect(t, ['total: price$100.00 and a*b+c? done'])
+    expect(result).toBe('total: [REDACTED] and [REDACTED] done')
+  })
+
+  it('flushes buffered tail on stream end', async () => {
+    const t = new RedactTransform(['secret'])
+    // Send short data that will be entirely buffered as tail
+    const result = await collect(t, ['sec', 'ret'])
+    expect(result).toBe('[REDACTED]')
+  })
+
+  it('handles empty chunks', async () => {
+    const t = new RedactTransform(['hidden'])
+    const result = await collect(t, ['before ', '', 'hidden', '', ' after'])
+    expect(result).toBe('before [REDACTED] after')
+  })
+
+  it('handles secret at very start of stream', async () => {
+    const t = new RedactTransform(['START'])
+    const result = await collect(t, ['START of the line'])
+    expect(result).toBe('[REDACTED] of the line')
+  })
+
+  it('handles secret at very end of stream', async () => {
+    const t = new RedactTransform(['END'])
+    const result = await collect(t, ['at the END'])
+    expect(result).toBe('at the [REDACTED]')
+  })
+
+  it('handles overlapping secret prefixes correctly', async () => {
+    const t = new RedactTransform(['abcd', 'abef'])
+    const result = await collect(t, ['abcd and abef'])
+    expect(result).toBe('[REDACTED] and [REDACTED]')
+  })
+
+  it('prefers longer secret match when secrets overlap', async () => {
+    const t = new RedactTransform(['pass', 'password'])
+    const result = await collect(t, ['my password is set'])
+    expect(result).toBe('my [REDACTED] is set')
+  })
+
+  it('filters out empty strings from secrets list', async () => {
+    const t = new RedactTransform(['', 'real-secret', ''])
+    const result = await collect(t, ['the real-secret is here'])
+    expect(result).toBe('the [REDACTED] is here')
+  })
+})

--- a/src/core/redact.ts
+++ b/src/core/redact.ts
@@ -1,0 +1,115 @@
+import { Transform } from 'node:stream'
+import type { TransformCallback } from 'node:stream'
+
+const REDACTED = '[REDACTED]'
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+export class RedactTransform extends Transform {
+  private readonly pattern: RegExp | null
+  private readonly maxSecretLen: number
+  private pending: string
+
+  constructor(secrets: string[]) {
+    super({ decodeStrings: true, encoding: 'utf-8' })
+
+    const filtered = secrets.filter((s) => s.length > 0)
+    this.pending = ''
+
+    if (filtered.length === 0) {
+      this.pattern = null
+      this.maxSecretLen = 0
+    } else {
+      // Sort by length descending so longer secrets match first
+      const sorted = [...filtered].sort((a, b) => b.length - a.length)
+      this.pattern = new RegExp(sorted.map(escapeRegex).join('|'), 'g')
+      this.maxSecretLen = sorted[0].length
+    }
+  }
+
+  _transform(chunk: Buffer, _encoding: string, callback: TransformCallback) {
+    if (!this.pattern) {
+      this.push(chunk)
+      callback()
+      return
+    }
+
+    this.pending += chunk.toString()
+    this.emitSafe()
+    callback()
+  }
+
+  _flush(callback: TransformCallback) {
+    if (this.pending.length > 0) {
+      if (this.pattern) {
+        this.pattern.lastIndex = 0
+        this.push(this.pending.replace(this.pattern, REDACTED))
+      } else {
+        this.push(this.pending)
+      }
+      this.pending = ''
+    }
+    callback()
+  }
+
+  /**
+   * Scans the pending buffer for secrets and emits as much redacted output
+   * as possible, holding back enough tail bytes to handle boundary splits.
+   *
+   * Strategy: run the regex on the full pending buffer to find all matches,
+   * then emit everything up to `safeEnd` (pending.length - maxSecretLen + 1),
+   * applying replacements for matches that fall within the emitted portion.
+   * Keep the remainder as the new pending buffer.
+   */
+  private emitSafe(): void {
+    if (!this.pattern) return
+
+    const holdBack = this.maxSecretLen - 1
+    if (this.pending.length <= holdBack) return
+
+    // safeEnd: we can commit to emitting original chars [0, safeEnd).
+    // Any secret starting before safeEnd is guaranteed to be fully visible
+    // in pending (since pending has at least safeEnd + holdBack = pending.length chars).
+    const safeEnd = this.pending.length - holdBack
+
+    // Find all matches in the full pending buffer
+    this.pattern.lastIndex = 0
+    const matches: { index: number; length: number }[] = []
+    let m: RegExpExecArray | null
+    while ((m = this.pattern.exec(this.pending)) !== null) {
+      matches.push({ index: m.index, length: m[0].length })
+    }
+
+    // Build the output for chars [0, consumedEnd), applying replacements.
+    // consumedEnd starts at safeEnd but may extend further if a match that
+    // starts before safeEnd extends past it.
+    let consumedEnd = safeEnd
+    let output = ''
+    let cursor = 0
+    for (const match of matches) {
+      // Only include matches that START before safeEnd
+      if (match.index >= safeEnd) break
+
+      // Emit text before this match
+      output += this.pending.slice(cursor, match.index)
+      output += REDACTED
+      cursor = match.index + match.length
+      // If the match extends past safeEnd, advance consumedEnd
+      if (cursor > consumedEnd) {
+        consumedEnd = cursor
+      }
+    }
+
+    // Emit remaining text up to consumedEnd
+    if (cursor < consumedEnd) {
+      output += this.pending.slice(cursor, consumedEnd)
+    }
+
+    this.pending = this.pending.slice(consumedEnd)
+    if (output.length > 0) {
+      this.push(output)
+    }
+  }
+}


### PR DESCRIPTION
Fixes #43

## Add stdout/stderr secret redaction to injector

## Summary

Wrap subprocess stdout and stderr streams to redact any secret values that appear in the output, replacing them with `[REDACTED]`.

## Context

When secrets are injected into a subprocess, the process might accidentally log or echo them. Redaction prevents secret leakage in terminal output and captured logs.

## Implementation Details

### Redaction transform (`src/core/injector.ts` or new `src/core/redact.ts`)
- Create a `RedactTransform` (Node.js Transform stream) that:
  - Takes a list of secret values to redact
  - Replaces any occurrence of those values in the data stream with `[REDACTED]`
  - Handles the case where a secret value spans chunk boundaries (buffer the last N bytes where N = max secret length - 1)
  - Is efficient for multiple secrets (build a combined regex or use Aho-Corasick-style matching)

### Integration with injector (`src/core/injector.ts`)
- After resolving all secrets (from explicit `--env` and `2k://` placeholders), collect the list of secret values
- Pipe `child.stdout` and `child.stderr` through `RedactTransform` before capturing output
- The `ProcessResult.stdout` and `ProcessResult.stderr` contain redacted output
- Also redact in real-time if streaming to the terminal

### CLI (`src/cli/request.ts`)
- stdout/stderr output to terminal is already redacted (comes from ProcessResult)
- No additional CLI changes needed

### Tests
- Test basic redaction: secret appears in stdout → replaced with `[REDACTED]`
- Test multi-secret redaction
- Test secret spanning chunk boundaries
- Test no false positives on partial matches
- Test empty secret list (no-op passthrough)
- Test stderr redaction independently

## Acceptance Criteria

- [ ] Any secret value appearing in subprocess stdout is replaced with `[REDACTED]`
- [ ] Any secret value appearing in subprocess stderr is replaced with `[REDACTED]`
- [ ] Redaction handles secrets split across stream chunks
- [ ] Multiple secrets are all redacted in a single stream
- [ ] ProcessResult contains only redacted output
- [ ] All tests passing

## Dependencies

- Depends on placeholder scanning issue (needs the resolved secret values list)

## Scope Boundaries

- Does NOT redact stdin (subprocess input)
- Does NOT modify how secrets are stored or fetched
- Does NOT change grant or request models

---
*This PR was created automatically by iloom.*